### PR TITLE
Several changes regarding layout

### DIFF
--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -166,10 +166,10 @@ public class Cell<T extends PDPage> {
 
 	public Paragraph getParagraph() {
 		if (paragraph == null) {
-			if(isHeaderCell){
-				paragraph = new Paragraph(text, fontBold, fontSize, getInnerWidth(), align, wrappingFunction);
+			if (isHeaderCell) {
+				paragraph = new Paragraph(text, fontBold, fontSize, getInnerWidth(), align, textColor, null, wrappingFunction);
 			} else {
-				paragraph = new Paragraph(text, font, fontSize, getInnerWidth(), align, wrappingFunction);
+				paragraph = new Paragraph(text, font, fontSize, getInnerWidth(), align, textColor, null, wrappingFunction);
 			}
 		}
 		return paragraph;

--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -273,7 +273,4 @@ public class Cell<T extends PDPage> {
 		return fontBold;
 	}
 
-	public Border getBorder() {
-		return border;
-	}
 }


### PR DESCRIPTION
We merged all forks that were available and added a few features:
* custom text wrap points (provided by @slampisko)
* cell alignment (horizontal and vertical)
* cell padding
* table titles
* page break if the first data row does not fit on the page
* migrated to pdfbox-2.0.0-RC2
* introduced concept of PageProvider to separate creation of a new page from the Table class
* added some debug PDF output, like drawing the font descent, ascent and height

We did not touch the API (just extended it and marked some methods and classes as deprecated), except the changes needed for using the new version of pdfbox.

Sorry for the single massive PR. We are currently working on further changes and will divide them up into smaller chunks.