### PR TITLE
Support for border only around tables and non-splitting tables

### DIFF
--- a/src/main/java/be/quodlibet/boxable/AbstractTemplatedTable.java
+++ b/src/main/java/be/quodlibet/boxable/AbstractTemplatedTable.java
@@ -27,7 +27,7 @@ public abstract class AbstractTemplatedTable<T extends AbstractPageTemplate> ext
     }
 
     public AbstractTemplatedTable(float yStartNewPage, float bottomMargin, float width, float margin, PDDocument document, boolean drawLines, boolean drawContent, PageProvider<T> pageProvider) throws IOException {
-        super(yStartNewPage, 0, bottomMargin, width, margin, document, drawLines, drawContent, pageProvider);
+        super(yStartNewPage, 0, bottomMargin, width, margin, document, drawLines, drawContent, false, pageProvider);
         setYStart(getCurrentPage().yStart());
     }
 

--- a/src/main/java/be/quodlibet/boxable/BaseTable.java
+++ b/src/main/java/be/quodlibet/boxable/BaseTable.java
@@ -13,16 +13,16 @@ import be.quodlibet.boxable.page.PageProvider;
  */
 public class BaseTable extends Table<PDPage> {
 
-    public BaseTable(float yStart, float yStartNewPage, float bottomMargin, float width, float margin, PDDocument document, PDPage currentPage, boolean drawLines, boolean drawContent) throws IOException {
-        super(yStart, yStartNewPage, 0, bottomMargin, width, margin, document, currentPage, drawLines, drawContent, new DefaultPageProvider(document, currentPage.getMediaBox()));
+  public BaseTable(float yStart, float yStartNewPage, float bottomMargin, float width, float margin, PDDocument document, PDPage currentPage, boolean drawLines, boolean drawContent, boolean drawBorders) throws IOException {
+    super(yStart, yStartNewPage, 0, bottomMargin, width, margin, document, currentPage, drawLines, drawContent, drawBorders, new DefaultPageProvider(document, currentPage.getMediaBox()));
     }
     
-    public BaseTable(float yStart, float yStartNewPage, float pageTopMargin, float bottomMargin, float width, float margin, PDDocument document, PDPage currentPage, boolean drawLines, boolean drawContent) throws IOException {
-        super(yStart, yStartNewPage, pageTopMargin, bottomMargin, width, margin, document, currentPage, drawLines, drawContent, new DefaultPageProvider(document, currentPage.getMediaBox()));
+    public BaseTable(float yStart, float yStartNewPage, float pageTopMargin, float bottomMargin, float width, float margin, PDDocument document, PDPage currentPage, boolean drawLines, boolean drawContent, boolean drawBorders) throws IOException {
+        super(yStart, yStartNewPage, pageTopMargin, bottomMargin, width, margin, document, currentPage, drawLines, drawContent, drawBorders, new DefaultPageProvider(document, currentPage.getMediaBox()));
     }
     
-    public BaseTable(float yStart, float yStartNewPage, float pageTopMargin, float bottomMargin, float width, float margin, PDDocument document, PDPage currentPage, boolean drawLines, boolean drawContent, final PageProvider<PDPage> pageProvider) throws IOException {
-        super(yStart, yStartNewPage, pageTopMargin, bottomMargin, width, margin, document, currentPage, drawLines, drawContent, pageProvider);
+    public BaseTable(float yStart, float yStartNewPage, float pageTopMargin, float bottomMargin, float width, float margin, PDDocument document, PDPage currentPage, boolean drawLines, boolean drawContent, boolean drawBorders, final PageProvider<PDPage> pageProvider) throws IOException {
+        super(yStart, yStartNewPage, pageTopMargin, bottomMargin, width, margin, document, currentPage, drawLines, drawContent, drawBorders, pageProvider);
     }
 
     @Override

--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -34,7 +34,7 @@ public class Cell<T extends PDPage> {
 	private float topPadding = 5f;
 	private float bottomPadding = 5f;
 
-	private Paragraph paragraph = null;
+	protected Paragraph paragraph = null;
 
 	private final HorizontalAlignment align;
 	private final VerticalAlignment valign;
@@ -163,6 +163,10 @@ public class Cell<T extends PDPage> {
 		// paragraph invalidated
 		paragraph = null;
 	}
+
+  public void setParagraph(Paragraph paragraph) {
+    this.paragraph = paragraph;
+  }
 
 	public Paragraph getParagraph() {
 		if (paragraph == null) {

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -48,6 +48,7 @@ public abstract class Table<T extends PDPage> {
   private boolean canBeSplit = true;
 	private final boolean drawContent;
 	private float headerBottomMargin = 4f;
+  private float lineWidth = 1.0f;
 
 	private boolean tableIsBroken = false;
 
@@ -444,6 +445,7 @@ public abstract class Table<T extends PDPage> {
 
 		this.tableContentStream.setNonStrokingColor(Color.BLACK);
 		this.tableContentStream.setStrokingColor(Color.BLACK);
+    this.tableContentStream.setLineWidth(lineWidth);
 
 		this.tableContentStream.moveTo(xStart, yStart);
 		this.tableContentStream.lineTo(xEnd, yEnd);
@@ -594,5 +596,13 @@ public abstract class Table<T extends PDPage> {
 
   public void setCanBeSplit(boolean canBeSplit) {
     this.canBeSplit = canBeSplit;
+  }
+
+  public float getLineWidth() {
+    return lineWidth;
+  }
+
+  public void setLineWidth(float lineWidth) {
+    this.lineWidth = lineWidth;
   }
 }

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -44,6 +45,8 @@ public abstract class Table<T extends PDPage> {
 	private float yStart;
 	private final float width;
 	private final boolean drawLines;
+  private boolean drawBorder;
+  private boolean canBeSplit = true;
 	private final boolean drawContent;
 	private float headerBottomMargin = 4f;
 
@@ -63,7 +66,7 @@ public abstract class Table<T extends PDPage> {
 	@Deprecated
 	public Table(float yStart, float yStartNewPage, float pageBottomMargin, float width, float margin,
 			PDDocument document, T currentPage, boolean drawLines, boolean drawContent) throws IOException {
-		this(yStart, yStartNewPage, 0, pageBottomMargin, width, margin, document, currentPage, drawLines, drawContent,
+		this(yStart, yStartNewPage, 0, pageBottomMargin, width, margin, document, currentPage, drawLines, drawContent,false,
 				null);
 	}
 
@@ -73,16 +76,23 @@ public abstract class Table<T extends PDPage> {
 	@Deprecated
 	public Table(float yStartNewPage, float pageBottomMargin, float width, float margin, PDDocument document,
 			boolean drawLines, boolean drawContent) throws IOException {
-		this(yStartNewPage, 0, pageBottomMargin, width, margin, document, drawLines, drawContent, null);
+		this(yStartNewPage, 0, pageBottomMargin, width, margin, document, drawLines, drawContent, false, null);
 	}
 
+  public Table(float yStart, float yStartNewPage, float pageTopMargin, float pageBottomMargin, float width,
+               float margin, PDDocument document, T currentPage, boolean drawLines, boolean drawContent,
+               PageProvider<T> pageProvider) throws IOException {
+    this(yStart, yStartNewPage, pageTopMargin, pageBottomMargin, width, margin, document, currentPage, drawLines, drawContent, false, pageProvider);
+  }
+
 	public Table(float yStart, float yStartNewPage, float pageTopMargin, float pageBottomMargin, float width,
-			float margin, PDDocument document, T currentPage, boolean drawLines, boolean drawContent,
-			PageProvider<T> pageProvider) throws IOException {
+                     float margin, PDDocument document, T currentPage, boolean drawLines, boolean drawContent, boolean drawBorder,
+                     PageProvider<T> pageProvider) throws IOException {
 		this.pageTopMargin = pageTopMargin;
 		this.document = document;
 		this.drawLines = drawLines;
 		this.drawContent = drawContent;
+                this.drawBorder = drawBorder;
 		// Initialize table
 		this.yStartNewPage = yStartNewPage;
 		this.margin = margin;
@@ -96,12 +106,13 @@ public abstract class Table<T extends PDPage> {
 	}
 
 	public Table(float yStartNewPage, float pageTopMargin, float pageBottomMargin, float width, float margin,
-			PDDocument document, boolean drawLines, boolean drawContent, PageProvider<T> pageProvider)
+                     PDDocument document, boolean drawLines, boolean drawContent, boolean drawBorder, PageProvider<T> pageProvider)
 					throws IOException {
 		this.pageTopMargin = pageTopMargin;
 		this.document = document;
 		this.drawLines = drawLines;
 		this.drawContent = drawContent;
+                this.drawBorder = drawBorder;
 		// Initialize table
 		this.yStartNewPage = yStartNewPage;
 		this.margin = margin;
@@ -118,7 +129,7 @@ public abstract class Table<T extends PDPage> {
 	protected abstract void loadFonts() throws IOException;
 
 	protected PDType0Font loadFont(String fontPath) throws IOException {
-		return FontUtils.loadFont(getDocument(), fontPath);
+    return FontUtils.loadFont(getDocument(), fontPath);
 	}
 
 	protected PDDocument getDocument() {
@@ -185,7 +196,19 @@ public abstract class Table<T extends PDPage> {
 
 	public float draw() throws IOException {
 		ensureStreamIsOpen();
-		
+
+    if (!canBeSplit) {
+      // verify that all rows fit.
+      float d = 0f;
+      for (Row<T> row: rows) {
+        d = d + row.getHeight();
+      }
+      //double d = rows.stream().collect(Collectors.summingDouble(Row::getHeight));
+      if (isEndOfPage((float)d)) {
+        pageBreak();
+      }
+    }
+
 		for (Row<T> row : rows) {
 			if (row == header) {
 				// check if header row height and first data row height can fit the page
@@ -223,12 +246,10 @@ public abstract class Table<T extends PDPage> {
 			// redraw all headers on each currentPage
 			if (header != null) {
 				drawRow(header);
-			} else {
-				LOGGER.warn("No Header Row Defined.");
 			}
 		}
 
-		if (drawLines) {
+		if (drawLines || drawBorder) {
 			drawVerticalLines(row);
 		}
 
@@ -386,8 +407,13 @@ public abstract class Table<T extends PDPage> {
 		// give an extra margin to the latest cell
 		float xEnd = row.xEnd();
 
-		// Draw Row upper border
-		drawLine("Row Upper Border ", xStart, yStart, xEnd, yStart);
+                if (drawLines) {
+                  // Draw Row upper border
+                  drawLine("Row Upper Border ", xStart, yStart, xEnd, yStart);
+                }
+                else if (drawBorder && (rows.indexOf(row) == 0)) {
+                  drawLine("Row Upper Border ", xStart, yStart, xEnd, yStart);
+                }
 
 		Iterator<Cell<T>> cellIterator = row.getCells().iterator();
 		while (cellIterator.hasNext()) {
@@ -397,8 +423,14 @@ public abstract class Table<T extends PDPage> {
 
 			float yEnd = yStart - row.getHeight();
 
-			// draw the vertical line to separate cells
-			drawLine("Cell Separator ", xStart, yStart, xStart, yEnd);
+                        if (drawLines) {
+                          // draw the vertical line to separate cells
+                          drawLine("Cell Separator ", xStart, yStart, xStart, yEnd);
+                        }
+                        else if (drawBorder && (row.getCells().indexOf(cell) == 0)) {
+                          drawLine("Cell Separator ", xStart, yStart, xStart, yEnd);
+                        }
+                          
 
 			xStart += getWidth(cell, cellIterator);
 		}
@@ -457,7 +489,7 @@ public abstract class Table<T extends PDPage> {
 	}
 
 	private void endTable() throws IOException {
-		if (drawLines) {
+          if (drawLines || drawBorder) {
 			// Draw line at bottom
 			drawLine("Row Bottom Border ", this.margin, this.yStart, this.margin + width, this.yStart);
 		}
@@ -474,7 +506,7 @@ public abstract class Table<T extends PDPage> {
 		boolean isEndOfPage = currentY <= pageBottomMargin;
 		if (isEndOfPage) {
 			setTableIsBroken(true);
-			System.out.println("Its end of page. Table row height caused the problem.");
+			//System.out.println("Its end of page. Table row height caused the problem.");
 		}
 
 		// If we are closer than bottom margin, consider this as
@@ -490,7 +522,7 @@ public abstract class Table<T extends PDPage> {
 		boolean isEndOfPage = currentY <= pageBottomMargin;
 		if (isEndOfPage) {
 			setTableIsBroken(true);
-			System.out.println("Its end of the page. Table title caused this problem.");
+			//System.out.println("Its end of the page. Table title caused this problem.");
 		}
 		return isEndOfPage;
 	}
@@ -517,9 +549,6 @@ public abstract class Table<T extends PDPage> {
 	}
 
 	public Row<T> getHeader() {
-		if (header == null) {
-			throw new IllegalArgumentException("Header Row not set on table");
-		}
 		return header;
 	}
 
@@ -539,6 +568,14 @@ public abstract class Table<T extends PDPage> {
 		this.drawDebug = drawDebug;
 	}
 
+	public boolean isDrawBorder() {
+		return drawBorder;
+	}
+
+	public void setDrawBorder(boolean drawBorder) {
+          this.drawBorder = drawBorder;
+	}
+  
 	public boolean tableIsBroken() {
 		return tableIsBroken;
 	}
@@ -552,4 +589,11 @@ public abstract class Table<T extends PDPage> {
 		this.tableIsBroken = tableIsBroken;
 	}
 
+  public boolean isCanBeSplit() {
+    return canBeSplit;
+  }
+
+  public void setCanBeSplit(boolean canBeSplit) {
+    this.canBeSplit = canBeSplit;
+  }
 }

--- a/src/test/java/be/quodlibet/boxable/TableTest.java
+++ b/src/test/java/be/quodlibet/boxable/TableTest.java
@@ -40,7 +40,7 @@ public class TableTest {
         boolean drawContent = true;
         float yStart = yStartNewPage;
         float bottomMargin = 70;
-        BaseTable table  = new BaseTable(yStart,yStartNewPage, bottomMargin, tableWidth, margin, doc, page, true, drawContent);
+        BaseTable table  = new BaseTable(yStart,yStartNewPage, bottomMargin, tableWidth, margin, doc, page, true, false, drawContent);
 
         //Create Header row
         Row<PDPage> headerRow = table.createRow(15f);
@@ -170,7 +170,7 @@ public class TableTest {
         boolean drawLines = true;
         float yStart = yStartNewPage;
         float bottomMargin = 70;
-        BaseTable table = new BaseTable(yStart,yStartNewPage,bottomMargin,tableWidth, margin, doc, page, drawLines, drawContent);
+        BaseTable table = new BaseTable(yStart,yStartNewPage,bottomMargin,tableWidth, margin, doc, page, drawLines, drawContent, false);
 
 
         //Create Header row


### PR DESCRIPTION
I wanted to force a small table to fit on a page and force a page break instead of splitting.
I also wanted to have a table where the lines are drawn around the table but not on each cell.
