### PR TITLE
#24: Font in header

### DIFF
--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -273,4 +273,17 @@ public class Cell<T extends PDPage> {
 		return fontBold;
 	}
 
+	/**
+	 * <p>
+	 * Sets the {@linkplain PDFont font} used for bold text, for example in
+	 * {@linkplain #isHeaderCell() header cells}.
+	 * </p>
+	 * 
+	 * @param fontBold
+	 *            The {@linkplain PDFont font} to use for bold text
+	 */
+	public void setFontBold(final PDFont fontBold) {
+		this.fontBold = fontBold;
+	}
+
 }


### PR DESCRIPTION
Added ```Cell.setFontBold(PDFont)```, so the user can set the font used for bold text, for example in the header rows. This should fix #24.