### PR TITLE
bug fix: LinkedHashMap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,7 @@ dependencies {
 	compile 'org.apache.pdfbox:pdfbox:2.0.0-RC2'
 	compile 'org.slf4j:slf4j-api:1.7.10'
 	compile 'com.google.guava:guava:18.0'
+	compile 'org.apache.commons:commons-csv:1.2'
 	testCompile 'junit:junit:4.12'
+	testCompile 'commons-io:commons-io:2.4'
 }

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -8,6 +8,7 @@ import java.awt.Color;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +43,7 @@ public class Paragraph {
 
 	private boolean drawDebug;
 	private final Map<Integer, Float> lineWidths = new HashMap<>();
-	private Map<Integer, List<Token>> mapLineTokens = new HashMap<>();
+	private Map<Integer, List<Token>> mapLineTokens = new LinkedHashMap<>();
 	private float maxLineWidth = Integer.MIN_VALUE;
 
 	public Paragraph(String text, PDFont font, float fontSize, float width, final HorizontalAlignment align) {


### PR DESCRIPTION
Solution for issue #52 
- fixed: using `LinkedHashMap` instead of `HashMap`
- added in build.gradle two `apache:common` libraries