### PR TITLE
bugfix: fixed endless loop if cell width is really small

### DIFF
--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -342,14 +342,12 @@ public class Paragraph {
 //					sinceLastWrapPoint.push(currentFont, fontSize, token);
 
 					String word = token.getData();
-//					breakWithinWords in if()
-					if (font.getStringWidth(word) / 1000f * fontSize > width && width > font.getAverageFontWidth() / 1000f * fontSize) {
+					if(font.getStringWidth(word) / 1000f * fontSize > width && width > font.getAverageFontWidth() / 1000f * fontSize) {
 						// you need to check if you have already something in your line 
 						boolean alreadyTextInLine = false;
 						if(textInLine.trimmedWidth()>0){
 							alreadyTextInLine = true;
 						}
-						
 						while (font.getStringWidth(word) / 1000f * fontSize > width) {
 						float width = 0;
 						float firstPartWordWidth = 0;
@@ -377,8 +375,17 @@ public class Paragraph {
 									firstPartOfWord.append("" + c);
 									firstPartWordWidth = Math.max(width, firstPartWordWidth);
 								} else {
-									restOfTheWord.append("" + c);
-									restOfTheWordWidth = Math.max(width, restOfTheWordWidth);
+									if(i==0){
+										firstPartOfWord.append("" + c);
+										for (int j = 1; j< lastTextToken.length(); j++){
+											restOfTheWord.append("" + lastTextToken.charAt(j));
+										}
+										break;
+									} else {
+										restOfTheWord.append("" + c);
+										restOfTheWordWidth = Math.max(width, restOfTheWordWidth);
+										
+									}
 								}
 							}
 						}


### PR DESCRIPTION
When cell width's is smaller than current font width from **one** letter then we are stuck in infinitive loop (`Paragraph` class, `getLines()` method, `while()` loop). This case can happen if we make wild left&right padding in cells that already have small width.

If this situation occur, Paragraph will store cell's content letter by letter, so if we have **Hello** he will make cell with next content :
**H
e
l
l
o**

I thought it would be better to hold cell content even if format will be pretty bad than remove cell's content completly. 

