### PR TITLE
bugfix-issue74: Drawing < charachter in the cell

### DIFF
--- a/src/main/java/be/quodlibet/boxable/text/Tokenizer.java
+++ b/src/main/java/be/quodlibet/boxable/text/Tokenizer.java
@@ -234,9 +234,9 @@ public final class Tokenizer {
 							}
 						}
 						
-						if (!consumed) {
-							sb.append('<');
-						}
+					}
+					if (!consumed) {
+						sb.append('<');
 					}
 					break;
 				default:

--- a/src/test/java/be/quodlibet/boxable/TableTest.java
+++ b/src/test/java/be/quodlibet/boxable/TableTest.java
@@ -3,37 +3,42 @@
  */
 package be.quodlibet.boxable;
 
-import be.quodlibet.boxable.utils.ImageUtils;
-import com.google.common.io.Files;
 import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.junit.Test;
+
+import com.google.common.io.Files;
+
+import be.quodlibet.boxable.datatable.DataTable;
+import be.quodlibet.boxable.utils.ImageUtils;
 
 public class TableTest {
 
 	@Test
 	public void Sample1() throws IOException {
 
-		//Set margins
+		// Set margins
 		float margin = 10;
 
 		List<String[]> facts = getFacts();
 
-		//Initialize Document
+		// Initialize Document
 		PDDocument doc = new PDDocument();
 		PDPage page = addNewPage(doc);
 		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
 
-		//Initialize table
+		// Initialize table
 		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
 		boolean drawContent = true;
 		float yStart = yStartNewPage;
@@ -41,7 +46,7 @@ public class TableTest {
 		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, true,
 				drawContent);
 
-		//Create Header row
+		// Create Header row
 		Row<PDPage> headerRow = table.createRow(15f);
 		Cell<PDPage> cell = headerRow.createCell(100, "Awesome Facts About Belgium");
 		cell.setFont(PDType1Font.HELVETICA_BOLD);
@@ -50,7 +55,7 @@ public class TableTest {
 
 		table.addHeaderRow(headerRow);
 
-		//Create 2 column row
+		// Create 2 column row
 		Row<PDPage> row = table.createRow(15f);
 		cell = row.createCell(30, "Source:");
 		cell.setFont(PDType1Font.HELVETICA);
@@ -58,7 +63,7 @@ public class TableTest {
 		cell = row.createCell(70, "http://www.factsofbelgium.com/");
 		cell.setFont(PDType1Font.HELVETICA_OBLIQUE);
 
-		//Create Fact header row
+		// Create Fact header row
 		Row<PDPage> factHeaderrow = table.createRow(15f);
 
 		cell = factHeaderrow.createCell((100 / 3f) * 2, "Fact");
@@ -71,7 +76,7 @@ public class TableTest {
 		cell.setFont(PDType1Font.HELVETICA_OBLIQUE);
 		cell.setFontSize(6);
 
-		//Add multiple rows with random facts about Belgium
+		// Add multiple rows with random facts about Belgium
 		for (String[] fact : facts) {
 
 			row = table.createRow(10f);
@@ -93,7 +98,7 @@ public class TableTest {
 					cell = row.createCell((100 / 9f), fact[i]);
 					cell.setFont(PDType1Font.HELVETICA_OBLIQUE);
 					cell.setFontSize(6);
-					//Set colors
+					// Set colors
 					if (fact[i].contains("beer"))
 						cell.setFillColor(Color.yellow);
 					if (fact[i].contains("champion"))
@@ -104,7 +109,7 @@ public class TableTest {
 
 		table.draw();
 
-		//Close Stream and save pdf
+		// Close Stream and save pdf
 		File file = new File("target/BoxableSample1.pdf");
 		System.out.println("Sample file saved at : " + file.getAbsolutePath());
 		Files.createParentDirs(file);
@@ -164,7 +169,7 @@ public class TableTest {
 		facts.add(new String[] { "Rock Werchter is the Best Festival in the World", "festivals", "music",
 				"world champions" });
 
-		//Make the table a bit bigger
+		// Make the table a bit bigger
 		facts.addAll(facts);
 		facts.addAll(facts);
 		facts.addAll(facts);
@@ -175,20 +180,20 @@ public class TableTest {
 	@Test
 	public void SampleTest2() throws IOException {
 
-		//Set margins
+		// Set margins
 		float margin = 10;
 
 		List<String[]> facts = getFacts();
-		facts.addAll(getFacts());//ensure we have multiple pages
+		facts.addAll(getFacts());// ensure we have multiple pages
 
-		//A list of bookmarks of all the tables
+		// A list of bookmarks of all the tables
 		List<PDOutlineItem> bookmarks = new ArrayList<PDOutlineItem>();
 
-		//Initialize Document
+		// Initialize Document
 		PDDocument doc = new PDDocument();
 		PDPage page = addNewPage(doc);
 
-		//Initialize table
+		// Initialize table
 		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
 		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
 		boolean drawContent = true;
@@ -198,7 +203,7 @@ public class TableTest {
 		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
 				drawContent);
 
-		//Create Header row
+		// Create Header row
 		Row<PDPage> headerRow = table.createRow(15f);
 		Cell<PDPage> cell = headerRow.createCell(100, "Awesome Facts About Belgium");
 		cell.setFont(PDType1Font.HELVETICA_BOLD);
@@ -207,7 +212,7 @@ public class TableTest {
 
 		table.addHeaderRow(headerRow);
 
-		//Create 2 column row
+		// Create 2 column row
 		Row<PDPage> row = table.createRow(15f);
 		cell = row.createCell(75, "Source:");
 		cell.setFont(PDType1Font.HELVETICA);
@@ -215,7 +220,7 @@ public class TableTest {
 		cell = row.createCell(25, "http://www.factsofbelgium.com/");
 		cell.setFont(PDType1Font.HELVETICA_OBLIQUE);
 
-		//Create Fact header row
+		// Create Fact header row
 		Row<PDPage> factHeaderrow = table.createRow(15f);
 		cell = factHeaderrow.createCell((100 / 3f) * 2, "Fact");
 		cell.setFont(PDType1Font.HELVETICA);
@@ -227,7 +232,7 @@ public class TableTest {
 		cell.setFont(PDType1Font.HELVETICA_OBLIQUE);
 		cell.setFontSize(6);
 
-		//Add multiple rows with random facts about Belgium
+		// Add multiple rows with random facts about Belgium
 		int bookmarkid = 0;
 		for (String[] fact : facts) {
 
@@ -236,7 +241,7 @@ public class TableTest {
 			cell.setFont(PDType1Font.HELVETICA);
 			cell.setFontSize(6);
 
-			//Create a bookmark for each record
+			// Create a bookmark for each record
 			PDOutlineItem outlineItem = new PDOutlineItem();
 			outlineItem.setTitle((++bookmarkid) + ") " + fact[0]);
 			row.setBookmark(outlineItem);
@@ -256,7 +261,7 @@ public class TableTest {
 					cell.setFont(PDType1Font.HELVETICA_OBLIQUE);
 					cell.setFontSize(6);
 
-					//Set colors
+					// Set colors
 					if (fact[i].contains("beer"))
 						cell.setFillColor(Color.yellow);
 					if (fact[i].contains("champion"))
@@ -267,10 +272,10 @@ public class TableTest {
 		}
 		table.draw();
 
-		//Get all bookmarks of previous table
+		// Get all bookmarks of previous table
 		bookmarks.addAll(table.getBookmarks());
 
-		//Create document outline
+		// Create document outline
 		PDDocumentOutline outline = new PDDocumentOutline();
 
 		for (PDOutlineItem bm : bookmarks) {
@@ -279,7 +284,7 @@ public class TableTest {
 
 		doc.getDocumentCatalog().setDocumentOutline(outline);
 
-		//Save the document
+		// Save the document
 		File file = new File("target/BoxableSample2.pdf");
 		System.out.println("Sample file saved at : " + file.getAbsolutePath());
 		Files.createParentDirs(file);
@@ -297,14 +302,14 @@ public class TableTest {
 	 */
 	@Test
 	public void SampleTest3() throws IOException {
-		//Set margins
+		// Set margins
 		float margin = 10;
 
-		//Initialize Document
+		// Initialize Document
 		PDDocument doc = new PDDocument();
 		PDPage page = addNewPage(doc);
 
-		//Initialize table
+		// Initialize table
 		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
 		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
 		boolean drawContent = true;
@@ -314,7 +319,7 @@ public class TableTest {
 		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
 				drawContent);
 
-		//Create Header row
+		// Create Header row
 		Row<PDPage> row = table.createRow(15f);
 		Cell<PDPage> cell = row.createCell((100 / 3f), "Hello", HorizontalAlignment.get("center"),
 				VerticalAlignment.get("top"));
@@ -353,7 +358,7 @@ public class TableTest {
 		cell6.setFontSize(6);
 		table.draw();
 
-		//Save the document
+		// Save the document
 		File file = new File("target/BoxableSample3.pdf");
 		System.out.println("Sample file saved at : " + file.getAbsolutePath());
 		Files.createParentDirs(file);
@@ -371,20 +376,20 @@ public class TableTest {
 	@Test
 	public void SampleTest4() throws IOException {
 
-		//Set margins
+		// Set margins
 		float margin = 10;
 
 		List<String[]> facts = getFacts();
-		facts.addAll(getFacts());//ensure we have multiple pages
+		facts.addAll(getFacts());// ensure we have multiple pages
 
-		//A list of bookmarks of all the tables
+		// A list of bookmarks of all the tables
 		List<PDOutlineItem> bookmarks = new ArrayList<PDOutlineItem>();
 
-		//Initialize Document
+		// Initialize Document
 		PDDocument doc = new PDDocument();
 		PDPage page = addNewPage(doc);
 
-		//Initialize table
+		// Initialize table
 		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
 		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
 		boolean drawContent = true;
@@ -394,7 +399,7 @@ public class TableTest {
 		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
 				drawContent);
 
-		//Create header row
+		// Create header row
 		Row<PDPage> headerRow = table.createRow(15f);
 		Cell<PDPage> cell = headerRow.createCell(100, "Awesome Facts About Belgium");
 		cell.setFont(PDType1Font.HELVETICA_BOLD);
@@ -403,7 +408,7 @@ public class TableTest {
 
 		table.addHeaderRow(headerRow);
 
-		//Create second header row
+		// Create second header row
 		Row<PDPage> secondHeaderRow = table.createRow(15f);
 		cell = secondHeaderRow.createCell(75, "Source:");
 		cell.setFont(PDType1Font.HELVETICA);
@@ -427,7 +432,7 @@ public class TableTest {
 
 		table.addHeaderRow(factHeaderrow);
 
-		//Add multiple rows with random facts about Belgium
+		// Add multiple rows with random facts about Belgium
 		int bookmarkid = 0;
 		for (String[] fact : facts) {
 
@@ -436,7 +441,7 @@ public class TableTest {
 			cell.setFont(PDType1Font.HELVETICA);
 			cell.setFontSize(6);
 
-			//Create a bookmark for each record
+			// Create a bookmark for each record
 			PDOutlineItem outlineItem = new PDOutlineItem();
 			outlineItem.setTitle((++bookmarkid) + ") " + fact[0]);
 			row.setBookmark(outlineItem);
@@ -456,7 +461,7 @@ public class TableTest {
 					cell.setFont(PDType1Font.HELVETICA_OBLIQUE);
 					cell.setFontSize(6);
 
-					//Set colors
+					// Set colors
 					if (fact[i].contains("beer"))
 						cell.setFillColor(Color.yellow);
 					if (fact[i].contains("champion"))
@@ -467,10 +472,10 @@ public class TableTest {
 		}
 		table.draw();
 
-		//Get all bookmarks of previous table
+		// Get all bookmarks of previous table
 		bookmarks.addAll(table.getBookmarks());
 
-		//Create document outline
+		// Create document outline
 		PDDocumentOutline outline = new PDDocumentOutline();
 
 		for (PDOutlineItem bm : bookmarks) {
@@ -479,7 +484,7 @@ public class TableTest {
 
 		doc.getDocumentCatalog().setDocumentOutline(outline);
 
-		//Save the document
+		// Save the document
 		File file = new File("target/BoxableSample4.pdf");
 		System.out.println("Sample file saved at : " + file.getAbsolutePath());
 		Files.createParentDirs(file);
@@ -491,14 +496,14 @@ public class TableTest {
 	@Test
 	public void SampleTest5() throws IOException {
 
-		//Set margins
+		// Set margins
 		float margin = 10;
 
-		//Initialize Document
+		// Initialize Document
 		PDDocument doc = new PDDocument();
 		PDPage page = addNewPage(doc);
 
-		//Initialize table
+		// Initialize table
 		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
 		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
 		boolean drawContent = true;
@@ -508,27 +513,29 @@ public class TableTest {
 		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
 				drawContent);
 
-		//Create Header row
+		// Create Header row
 		Row<PDPage> row = table.createRow(15f);
 		Cell<PDPage> cell = row.createCell((100 / 3f), "<b>Here is bold</b>", HorizontalAlignment.get("center"),
 				VerticalAlignment.get("top"));
 		cell.setFontSize(6);
 
-		Cell<PDPage> cell2 = row.createCell((100 / 3f), "<i>Here is text in italic</i>", HorizontalAlignment.get("center"),
-				VerticalAlignment.get("middle"));
+		Cell<PDPage> cell2 = row.createCell((100 / 3f), "<i>Here is text in italic</i>",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("middle"));
 		cell2.setFontSize(6);
 
-		Cell<PDPage> cell3 = row.createCell((100 / 3f), "<b><i>Here is text in bold and italic</i></b>", HorizontalAlignment.get("center"),
-				VerticalAlignment.get("bottom"));
+		Cell<PDPage> cell3 = row.createCell((100 / 3f), "<b><i>Here is text in bold and italic</i></b>",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("bottom"));
 		cell3.setFontSize(6);
 
 		Row<PDPage> row2 = table.createRow(15f);
-		Cell<PDPage> cell4 = row2.createCell((100 / 3.0f), " <p>Integer eget elit vitae est feugiat laoreet. <b>Nam vitae ex commodo, euismod risus in, sodales dolor. Mauris condimentum urna neque, non condimentum odio</b> posuere a. Aenean nisl ex, semper eu malesuada sit amet, luctus nec enim. <br>Pellentesque eu ultrices magna, non porta dolor. Fus<b><i>ce eu neque nulla. Curabitur eu eros tristique leo efficitur fringilla sit amet sed neque. Aliquam</i></b> a tempor enim. Praesent pellentesque volutpat dolor, non rhoncus est posuere id. Aenean nunc purus, gravida at mauris et, pretium volutpat nisl. Mauris lacus urna, sodales ac eros in, mollis scelerisque neque.</p> Unordered List <ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>", HorizontalAlignment.get("center"),
-				VerticalAlignment.get("top"));
+		Cell<PDPage> cell4 = row2.createCell((100 / 3.0f),
+				" <p>Integer eget elit vitae est feugiat laoreet. <b>Nam vitae ex commodo, euismod risus in, sodales dolor. Mauris condimentum urna neque, non condimentum odio</b> posuere a. Aenean nisl ex, semper eu malesuada sit amet, luctus nec enim. <br>Pellentesque eu ultrices magna, non porta dolor. Fus<b><i>ce eu neque nulla. Curabitur eu eros tristique leo efficitur fringilla sit amet sed neque. Aliquam</i></b> a tempor enim. Praesent pellentesque volutpat dolor, non rhoncus est posuere id. Aenean nunc purus, gravida at mauris et, pretium volutpat nisl. Mauris lacus urna, sodales ac eros in, mollis scelerisque neque.</p> Unordered List <ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("top"));
 		cell4.setFontSize(6);
 
-		Cell<PDPage> cell5 = row2.createCell((100 / 3f), "<p>Proin dui dolor, lacinia at dui at, placerat ullamcorper arcu. Sed auctor sagittis elit, at eleifend ex aliquet ut. Duis lobortis est nec placerat condimentum. Aliquam erat volutpat. In a sem massa. Phasellus eget tortor iaculis, condimentum turpis a, sodales lorem. Aenean egestas congue ex<i> eu condimentum. Fusce sed</i> fringilla lorem. Vestibulum luctus ni<b>si ac turpis congue, vitae pharetra lorem suscipit.</b></p>Ordered List <ol><li>Item 1</li><li>Item 2</li><li>Item 3</li></ol>", HorizontalAlignment.get("center"),
-				VerticalAlignment.get("middle"));
+		Cell<PDPage> cell5 = row2.createCell((100 / 3f),
+				"<p>Proin dui dolor, lacinia at dui at, placerat ullamcorper arcu. Sed auctor sagittis elit, at eleifend ex aliquet ut. Duis lobortis est nec placerat condimentum. Aliquam erat volutpat. In a sem massa. Phasellus eget tortor iaculis, condimentum turpis a, sodales lorem. Aenean egestas congue ex<i> eu condimentum. Fusce sed</i> fringilla lorem. Vestibulum luctus ni<b>si ac turpis congue, vitae pharetra lorem suscipit.</b></p>Ordered List <ol><li>Item 1</li><li>Item 2</li><li>Item 3</li></ol>",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("middle"));
 		cell5.setFontSize(6);
 
 		Cell<PDPage> cell6 = row2.createCell((100 / 3f),
@@ -537,7 +544,7 @@ public class TableTest {
 		cell6.setFontSize(6);
 		table.draw();
 
-		//Save the document
+		// Save the document
 		File file = new File("target/BoxableSample5.pdf");
 		System.out.println("Sample file saved at : " + file.getAbsolutePath());
 		Files.createParentDirs(file);
@@ -548,14 +555,14 @@ public class TableTest {
 	@Test
 	public void SampleTest6() throws IOException {
 
-		//Set margins
+		// Set margins
 		float margin = 10;
 
-		//Initialize Document
+		// Initialize Document
 		PDDocument doc = new PDDocument();
 		PDPage page = addNewPage(doc);
 
-		//Initialize table
+		// Initialize table
 		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
 		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
 		boolean drawContent = true;
@@ -565,22 +572,23 @@ public class TableTest {
 		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
 				drawContent);
 
-		//Create Header row
+		// Create Header row
 		Row<PDPage> row = table.createRow(15f);
-		Cell<PDPage> cell = row.createCell((100 / 3f), "Hellooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo", HorizontalAlignment.get("center"),
-				VerticalAlignment.get("top"));
+		Cell<PDPage> cell = row.createCell((100 / 3f),
+				"Hellooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("top"));
 		cell.setFontSize(6);
 
-		Cell<PDPage> cell2 = row.createCell((100 / 3f), "<i>Here is text in italic</i>", HorizontalAlignment.get("center"),
-				VerticalAlignment.get("middle"));
+		Cell<PDPage> cell2 = row.createCell((100 / 3f), "<i>Here is text in italic</i>",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("middle"));
 		cell2.setFontSize(6);
 
-		Cell<PDPage> cell3 = row.createCell((100 / 3f), "<b><i>Here is text in bold and italic</i></b>", HorizontalAlignment.get("center"),
-				VerticalAlignment.get("bottom"));
+		Cell<PDPage> cell3 = row.createCell((100 / 3f), "<b><i>Here is text in bold and italic</i></b>",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("bottom"));
 		cell3.setFontSize(6);
 		table.draw();
 
-		//Save the document
+		// Save the document
 		File file = new File("target/BoxableSample6.pdf");
 		System.out.println("Sample file saved at : " + file.getAbsolutePath());
 		Files.createParentDirs(file);
@@ -591,14 +599,14 @@ public class TableTest {
 	@Test
 	public void SampleTest7() throws IOException {
 
-		//Set margins
+		// Set margins
 		float margin = 10;
 
-		//Initialize Document
+		// Initialize Document
 		PDDocument doc = new PDDocument();
 		PDPage page = addNewPage(doc);
 
-		//Initialize table
+		// Initialize table
 		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
 		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
 		boolean drawContent = true;
@@ -608,7 +616,7 @@ public class TableTest {
 		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
 				drawContent);
 
-		//Create Header row
+		// Create Header row
 		Row<PDPage> row = table.createRow(400f);
 		Cell<PDPage> cell = row.createCell((100 / 3f),
 				"<p>Integer eget elit vitae est feugiat laoreet. <b>Nam vitae ex commodo, euismod risus in, sodales dolor. Mauris condimentum urna neque, non condimentum odio</b> posuere a. Aenean nisl ex, semper eu malesuada sit amet, luctus nec enim. <br>Pellentesque eu ultrices magna, non porta dolor. Fus<b><i>ce eu neque nulla. Curabitur eu eros tristique leo efficitur fringilla sit amet sed neque. Aliquam</i></b> a tempor enim. Praesent pellentesque volutpat dolor, non rhoncus est posuere id. Aenean nunc purus, gravida at mauris et, pretium volutpat nisl. Mauris lacus urna, sodales ac eros in, mollis scelerisque neque.</p> Unordered List <ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>",
@@ -642,7 +650,7 @@ public class TableTest {
 		cell6.setFontSize(6);
 		table.draw();
 
-		//Save the document
+		// Save the document
 		File file = new File("target/BoxableSample7.pdf");
 		System.out.println("Sample file saved at : " + file.getAbsolutePath());
 		Files.createParentDirs(file);
@@ -651,16 +659,126 @@ public class TableTest {
 	}
 
 	@Test
-	public void lineSpacingTest() throws IOException {
-
-		//Set margins
+	public void SampleTest8() throws IOException {
+		// Set margins
 		float margin = 10;
 
-		//Initialize Document
+		// Initialize Document
+		PDDocument doc = new PDDocument();
+		PDPage page = new PDPage();
+		doc.addPage(page);
+
+		// Initialize table
+		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
+		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
+		boolean drawContent = true;
+		boolean drawLines = true;
+		float yStart = yStartNewPage;
+		float bottomMargin = 70;
+		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
+				drawContent);
+
+		// Create Header row
+		Row<PDPage> row = table.createRow(15f);
+		Cell<PDPage> cell = row.createCell(40f, "I want this < charachter is that okay? Maybe even this > also.",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("top"));
+		cell = row.createCell(20f, " | ");
+		cell = row.createCell(40f, "right comparison");
+
+		table.addHeaderRow(row);
+
+		Row<PDPage> subtractionRow = table.createRow(15f);
+		cell = subtractionRow.createCell(40f, "Removed Text From Document", HorizontalAlignment.get("center"),
+				VerticalAlignment.get("top"));
+		cell = subtractionRow.createCell(20f, " < ");
+		cell = subtractionRow.createCell(40f, "text here");
+
+		Row<PDPage> additionArow = table.createRow(15f);
+		cell = additionArow.createCell(40f, "no empty cells", HorizontalAlignment.get("center"),
+				VerticalAlignment.get("top"));
+		cell = additionArow.createCell(20f, " > ");
+		cell = additionArow.createCell(40f, "Added Text From Document");
+
+		cell.setFontSize(6);
+
+		table.draw();
+
+		// Save the document
+		File file = new File("target/BoxableSample8.pdf");
+		System.out.println("Sample file saved at : " + file.getAbsolutePath());
+		Files.createParentDirs(file);
+		doc.save(file);
+		doc.close();
+	}
+
+	@Test
+	public void SampleTest9() throws IOException {
+		List<List> table = new ArrayList<>();
+
+		List<String> tableHeader = new ArrayList<>();
+		tableHeader.add("Left Comparison");
+		tableHeader.add("  ");
+		tableHeader.add("Right Comparison");
+
+		table.add(tableHeader);
+
+		List<String> additionRow = new ArrayList<>();
+		additionRow.add("");
+		additionRow.add(">");
+		additionRow.add("Added Text To Document");
+		table.add(additionRow);
+
+		List<String> subtractionRow = new ArrayList<>();
+		subtractionRow.add("Removed Text From Document");
+		subtractionRow.add(" < ");
+		subtractionRow.add("center row just has < in it");
+		table.add(subtractionRow);
+
+		List<String> updateRow = new ArrayList<>();
+		updateRow.add("Original Text From Document");
+		updateRow.add(" | ");
+		updateRow.add("Changed Text From Document");
+		table.add(updateRow);
+
+		int startNewPageY = 700;
+		int bottomMargin = 100;
+		int tableWidth = 500;
+		int leftMargin = 25;
+
+		PDDocument document = new PDDocument();
+		PDPage currentPage = new PDPage();
+		document.addPage(currentPage);
+		PDPageContentStream contentStream = new PDPageContentStream(document, currentPage);
+
+		BaseTable dataTable = new BaseTable(700, startNewPageY, bottomMargin, tableWidth, leftMargin, document,
+				currentPage, true, true);
+		DataTable t = new DataTable(dataTable, currentPage);
+		t.addListToTable(table, DataTable.HASHEADER);
+		dataTable.draw();
+
+		contentStream.close();
+
+		try {
+			File file = new File("target/BoxableSample9.pdf");
+			System.out.println("Sample file saved at : " + file.getAbsolutePath());
+			Files.createParentDirs(file);
+			document.save(file);
+		} finally {
+			document.close();
+		}
+	}
+
+	@Test
+	public void lineSpacingTest() throws IOException {
+
+		// Set margins
+		float margin = 10;
+
+		// Initialize Document
 		PDDocument doc = new PDDocument();
 		PDPage page = addNewPage(doc);
 
-		//Initialize table
+		// Initialize table
 		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
 		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
 		boolean drawContent = true;
@@ -672,17 +790,17 @@ public class TableTest {
 
 		// set default line spacing for entire table
 		table.setLineSpacing(1.5f);
-		
+
 		Row<PDPage> row = table.createRow(100f);
-		
+
 		// set single spacing for entire row
 		row.setLineSpacing(1f);
-		
+
 		Cell<PDPage> cell = row.createCell((100 / 3f),
 				"<p>SINGLE SPACING</p><p>Integer eget elit vitae est feugiat laoreet. <b>Nam vitae ex commodo, euismod risus in, sodales dolor. Mauris condimentum urna neque, non condimentum odio</b> posuere a. Aenean nisl ex, semper eu malesuada sit amet, luctus nec enim. <br>Pellentesque eu ultrices magna, non porta dolor. Fus<b><i>ce eu neque nulla. Curabitur eu eros tristique leo efficitur fringilla sit amet sed neque. Aliquam</i></b> a tempor enim. Praesent pellentesque volutpat dolor, non rhoncus est posuere id. Aenean nunc purus, gravida at mauris et, pretium volutpat nisl. Mauris lacus urna, sodales ac eros in, mollis scelerisque neque.</p> Unordered List <ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>",
 				HorizontalAlignment.get("center"), VerticalAlignment.get("top"));
 		cell.setFontSize(6);
-		
+
 		Cell<PDPage> cell2 = row.createCell((100 / 3f),
 				"<p>SINGLE SPACING</p><p>Proin dui dolor, lacinia at dui at, placerat ullamcorper arcu. Sed auctor sagittis elit, at eleifend ex aliquet ut. Duis lobortis est nec placerat condimentum. Aliquam erat volutpat. In a sem massa. Phasellus eget tortor iaculis, condimentum turpis a, sodales lorem. Aenean egestas congue ex<i> eu condimentum. Fusce sed</i> fringilla lorem. Vestibulum luctus ni<b>si ac turpis congue, vitae pharetra lorem suscipit.</b></p>Ordered List <ol><li>Item 1</li><li>Item 2</li><li>Item 3</li></ol>",
 				HorizontalAlignment.get("center"), VerticalAlignment.get("middle"));
@@ -692,15 +810,15 @@ public class TableTest {
 				"<p>DOUBLE SPACING</p><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam at bibendum leo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aenean lobortis enim vitae magna varius, nec scelerisque sapien elementum. Quisque porta eros in feugiat commodo. Phasellus a elit diam. Nullam pretium lorem malesuada, ullamcorper risus eget, dictum libero. Nulla neque ante, volutpat in tincidunt eu, porttitor ut purus. Fusce at mauris velit. Pellentesque vel tincidunt erat. </p><p>In vehicula velit nunc, sit amet ultricies neque fringilla vel. Quisque ac enim nisl. Ut quis leo et lorem iaculis porttitor a semper diam. Pellentesque lobortis nisi ac ipsum efficitur facilisis. Interdum et malesuada fames ac ante ipsum primis in faucibus. Praesent in tellus velit. Maecenas volutpat ipsum lacus, non fringilla neque faucibus et.</p>",
 				HorizontalAlignment.get("center"), VerticalAlignment.get("bottom"));
 		cell3.setFontSize(6);
-		
+
 		// set double line spacing for this particular cell
 		cell3.setLineSpacing(2f);
-		
+
 		Row<PDPage> row2 = table.createRow(100f);
-		
+
 		// set double spacing for entire row
 		row2.setLineSpacing(2f);
-		
+
 		Cell<PDPage> cell4 = row2.createCell((100 / 3.0f),
 				" <p>DOUBLE SPACING</p><p>Integer eget elit vitae est feugiat laoreet. <b>Nam vitae ex commodo, euismod risus in, sodales dolor. Mauris condimentum urna neque, non condimentum odio</b> posuere a. Aenean nisl ex, semper eu malesuada sit amet, luctus nec enim. <br>Pellentesque eu ultrices magna, non porta dolor. Fus<b><i>ce eu neque nulla. Curabitur eu eros tristique leo efficitur fringilla sit amet sed neque. Aliquam</i></b> a tempor enim. Praesent pellentesque volutpat dolor, non rhoncus est posuere id. Aenean nunc purus, gravida at mauris et, pretium volutpat nisl. Mauris lacus urna, sodales ac eros in, mollis scelerisque neque.</p> Unordered List <ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>",
 				HorizontalAlignment.get("center"), VerticalAlignment.get("top"));
@@ -735,7 +853,7 @@ public class TableTest {
 
 		table.draw();
 
-		//Save the document
+		// Save the document
 		File file = new File("target/lineSpacingTest.pdf");
 		System.out.println("Sample file saved at : " + file.getAbsolutePath());
 		Files.createParentDirs(file);


### PR DESCRIPTION
Resolved small bug in `Tokenizer` class due drawing `<` charachter in the cell (#74). Added `SampleTest8()` and `SampleTest9()` as test cases.
Special thanks to @AUno-Antonison for pointing this out and I also used his test cases to demonstrate this fix.

PDF outputs:
[BoxableSample8.pdf](https://github.com/dhorions/boxable/files/471445/BoxableSample8.pdf)
[BoxableSample9.pdf](https://github.com/dhorions/boxable/files/471446/BoxableSample9.pdf)

