### PR TITLE
bugfix: incorrect nesting of list tags

### DIFF
--- a/src/main/java/be/quodlibet/boxable/HTMLListNode.java
+++ b/src/main/java/be/quodlibet/boxable/HTMLListNode.java
@@ -1,0 +1,48 @@
+package be.quodlibet.boxable;
+
+/**
+ * <p>
+ * Data container for HTML ordered list elements.
+ * </p>
+ * 
+ * @author hstimac
+ *
+ */
+public class HTMLListNode {
+
+	/**
+	 * <p>
+	 * Element's current ordering number (e.g third element in the current list)
+	 * </p>
+	 */
+	private int orderingNumber;
+
+	/**
+	 * <p>
+	 * Element's whole ordering number value (e.g 1.1.2.1)
+	 * </p>
+	 */
+	private String value;
+
+	public int getOrderingNumber() {
+		return orderingNumber;
+	}
+
+	public void setOrderingNumber(int orderingNumber) {
+		this.orderingNumber = orderingNumber;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public HTMLListNode(int orderingNumber, String value) {
+		this.orderingNumber = orderingNumber;
+		this.value = value;
+	}
+
+}

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -462,7 +462,7 @@ public abstract class Table<T extends PDPage> {
 				// new line
 				float lineStartX = cursorX;
 				float lineStartY = cursorY;
-
+				
 				// if it is head row or if it is header cell then please use bold font
 				if (row.equals(header) || cell.isHeaderCell()) {
 					this.tableContentStream.setFont(cell.getParagraph().getFont(true, false), cell.getFontSize());
@@ -552,6 +552,10 @@ public abstract class Table<T extends PDPage> {
 							}
 							break;
 						case BULLET:
+							// if cell is not left aligned then don't draw the bullet
+							if(!cell.getAlign().equals(HorizontalAlignment.LEFT)){
+								continue;
+							}
 							if (cell.isTextRotated()) {
 								// move cursorX up because bullet needs to be in the middle of font height
 								cursorX += FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;

--- a/src/test/java/be/quodlibet/boxable/TableTest.java
+++ b/src/test/java/be/quodlibet/boxable/TableTest.java
@@ -3,20 +3,24 @@
  */
 package be.quodlibet.boxable;
 
-import be.quodlibet.boxable.utils.ImageUtils;
-import com.google.common.io.Files;
 import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.junit.Test;
+
+import com.google.common.io.Files;
+
+import be.quodlibet.boxable.utils.ImageUtils;
 
 public class TableTest {
 
@@ -640,6 +644,40 @@ public class TableTest {
 
         //Save the document
         File file = new File("target/BoxableSample7.pdf");
+        System.out.println("Sample file saved at : " + file.getAbsolutePath());
+        Files.createParentDirs(file);
+        doc.save(file);
+        doc.close();
+    }
+    
+    @Test
+    public void IncorrectHTMLListNesting() throws IOException {
+
+        //Set margins
+        float margin = 10;
+
+        //Initialize Document
+        PDDocument doc = new PDDocument();
+        PDPage page = addNewPage(doc);
+
+        //Initialize table
+        float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
+        float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
+        boolean drawContent = true;
+        boolean drawLines = true;
+        float yStart = yStartNewPage;
+        float bottomMargin = 70;
+        BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
+                drawContent);
+
+        //Create Header row
+        Row<PDPage> row = table.createRow(15f);
+        Cell<PDPage> cell = row.createCell((100 / 3f), "<ol><li>a</li><ol><li>b1</li><li>b2</li><ol><li>c1</li><li>c2 hello hello hello hello hello hello hello hello hello hello hello </li><li>c3</li><li>c4 hello hello hello hello hello hello hello hello hello hello</li></ol><li>b3</li></ol><li>hello</li><li>hello</li><li>hello</li><li>hello</li><li>hello</li></ol>", HorizontalAlignment.get("left"), VerticalAlignment.get("top"));
+        Cell<PDPage> cell2 = row.createCell((100 / 3f), "<ul><li>a</li><ul><li>b1</li><li>b2</li><ul><li>c1</li><li>c2 hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello </li><li>c3</li><li>c4</li></ul><li>b3</li></ul><li>hello</li><li>hello</li><li>hello</li><li>hello</li></ul>", HorizontalAlignment.get("left"), VerticalAlignment.get("top"));
+        table.draw();
+
+        //Save the document
+        File file = new File("target/ListNesting.pdf");
         System.out.println("Sample file saved at : " + file.getAbsolutePath());
         Files.createParentDirs(file);
         doc.save(file);


### PR DESCRIPTION
Finally I find time for implementation of ordered lists ( #66 ) :smile: I also added a test case `IncorrectHTMLListNesting()` for this purpose. I must admit, I didn't play much with corner cases (e.g nested `<li>` elements and etc ...) so it would be good if can someone can test this bugfix with his example list or make some extra corner cases where output is not like expected.

Test case 
```xml
// first cell with ordered list
<ol>
	<li>a</li>
	<ol>
		<li>b1</li>
		<li>b2</li><
		<ol>
			<li>c1</li><
			<li>c2 hello hello hello hello hello hello hello hello hello hello hello </li>
			<li>c3</li><
			<li>c4 hello hello hello hello hello hello hello hello hello hello</li>
		</ol>
		<li>b3</li>
	</ol>
	<li>hello</li>
	<li>hello</li>
	<li>hello</li>
	<li>hello</li>
	<li>hello</li>
</ol>
--------------------------------------------------------------------------------
// second cell with unordered list
<ul>
	<li>a</li>
	<ul>
		<li>b1</li>
		<li>b2</li>
		<ul>
			<li>c1</li>
			<li>c2 hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello </li>
			<li>c3</li>
			<li>c4</li>
		</ul>
		<li>b3</li>
	</ul>
	<li>hello</li>
	<li>hello</li>
	<li>hello</li>
	<li>hello</li>
</ul>
```

Output:
[OrderedListNesting.pdf](https://github.com/dhorions/boxable/files/529382/OrderedListNesting.pdf)


