### PR TITLE
bugfix: incorrect nesting of list tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+task wrapper(type: Wrapper) {
+	gradleVersion = '2.13'
+}
+
 apply plugin: 'java'
 
 sourceCompatibility = 1.7

--- a/src/main/java/be/quodlibet/boxable/HTMLListNode.java
+++ b/src/main/java/be/quodlibet/boxable/HTMLListNode.java
@@ -1,0 +1,48 @@
+package be.quodlibet.boxable;
+
+/**
+ * <p>
+ * Data container for HTML ordered list elements.
+ * </p>
+ * 
+ * @author hstimac
+ *
+ */
+public class HTMLListNode {
+
+	/**
+	 * <p>
+	 * Element's current ordering number (e.g third element in the current list)
+	 * </p>
+	 */
+	private int orderingNumber;
+
+	/**
+	 * <p>
+	 * Element's whole ordering number value (e.g 1.1.2.1)
+	 * </p>
+	 */
+	private String value;
+
+	public int getOrderingNumber() {
+		return orderingNumber;
+	}
+
+	public void setOrderingNumber(int orderingNumber) {
+		this.orderingNumber = orderingNumber;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public HTMLListNode(int orderingNumber, String value) {
+		this.orderingNumber = orderingNumber;
+		this.value = value;
+	}
+
+}

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
@@ -41,6 +42,7 @@ public class Paragraph {
 
 	private final static int DEFAULT_TAB = 4;
 	private final static int DEFAULT_TAB_AND_BULLET = 6;
+	private final static int BULLET_SPACE = 2;
 
 	private boolean drawDebug;
 	private final Map<Integer, Float> lineWidths = new HashMap<>();
@@ -95,8 +97,10 @@ public class Paragraph {
 		boolean listElement = false;
 		PDFont currentFont = font;
 		int orderListElement = 1;
-		boolean orderList = false;
-
+		int numberOfOrderedLists = 0;
+		int listLevel = 0;
+		Stack<HTMLListNode> stack= new Stack<>();
+		
 		final PipelineLayer textInLine = new PipelineLayer();
 		final PipelineLayer sinceLastWrapPoint = new PipelineLayer();
 
@@ -110,16 +114,25 @@ public class Paragraph {
 					italic = true;
 					currentFont = getFont(bold, italic);
 				} else if (isList(token)) {
+					listLevel++;
 					if (token.getData().equals("ol")) {
-						orderList = true;
+						numberOfOrderedLists++;
+						if(listLevel > 1){
+							stack.add(new HTMLListNode(orderListElement-1, stack.isEmpty() ? String.valueOf("1.") : stack.peek().getValue() + String.valueOf(orderListElement-1) + "."));
+						}
+						orderListElement = 1;
+
 						textInLine.push(sinceLastWrapPoint);
-						// this is our line
-						result.add(textInLine.trimmedText());
-						lineWidths.put(lineCounter, textInLine.trimmedWidth());
-						mapLineTokens.put(lineCounter, textInLine.tokens());
-						maxLineWidth = Math.max(maxLineWidth, textInLine.trimmedWidth());
-						textInLine.reset();
-						lineCounter++;
+						// check if you have some text before this list, if you don't then you really don't need extra line break for that
+						if (textInLine.trimmedWidth() > 0) {
+							// this is our line
+							result.add(textInLine.trimmedText());
+							lineWidths.put(lineCounter, textInLine.trimmedWidth());
+							mapLineTokens.put(lineCounter, textInLine.tokens());
+							maxLineWidth = Math.max(maxLineWidth, textInLine.trimmedWidth());
+							textInLine.reset();
+							lineCounter++;
+						}
 					} else if (token.getData().equals("ul")) {
 						textInLine.push(sinceLastWrapPoint);
 						// check if you have some text before this list, if you don't then you really don't need extra line break for that
@@ -146,18 +159,27 @@ public class Paragraph {
 					currentFont = getFont(bold, italic);
 					sinceLastWrapPoint.push(token);
 				} else if (isList(token)) {
+					listLevel--;
 					if (token.getData().equals("ol")) {
-						orderList = false;
+						numberOfOrderedLists--;
 						// reset elements
-						orderListElement = 1;
+						orderListElement = stack.peek().getOrderingNumber()+1;
+						if(numberOfOrderedLists > 1){
+							stack.pop();
+						}
 					}
 					// ensure extra space after each lists
 					// no need to worry about current line text because last closing <li> tag already done that
-					result.add(" ");
-					lineWidths.put(lineCounter, 0.0f);
-					mapLineTokens.put(lineCounter, new ArrayList<Token>());
-					lineCounter++;
+					if(listLevel == 0){
+						result.add(" ");
+						lineWidths.put(lineCounter, 0.0f);
+						mapLineTokens.put(lineCounter, new ArrayList<Token>());
+						lineCounter++;
+					}
 				} else if (isListElement(token)) {
+					if(!getAlign().equals(HorizontalAlignment.LEFT)) {
+						listLevel = 0;
+					}
 					// wrap at last wrap point?
 					if (textInLine.width() + sinceLastWrapPoint.trimmedWidth() > width) {
 						// this is our line
@@ -168,8 +190,9 @@ public class Paragraph {
 						textInLine.reset();
 						lineCounter++;
 						// wrapping at last wrap point
-						if (orderList) {
-							String orderingNumber = String.valueOf(orderListElement) + ". ";
+						if (numberOfOrderedLists>0) {
+							String orderingNumber = stack.isEmpty() ? String.valueOf(orderListElement) + "." : stack.pop().getValue() + ".";
+							stack.add(new HTMLListNode(orderListElement, orderingNumber));
 							String tab = String.valueOf(indentLevel(DEFAULT_TAB));
 							String orderingNumberAndTab = orderingNumber + tab;
 							try {
@@ -178,10 +201,11 @@ public class Paragraph {
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
+							orderListElement++;
 						} else {
 							try {
-								// tab + bullet
-								String tabBullet = indentLevel(DEFAULT_TAB_AND_BULLET);
+								// if it's not left aligned then ignore list and list element and deal with it as normal text where <li> mimic <br> behaviour
+								String tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(DEFAULT_TAB_AND_BULLET) : indentLevel(DEFAULT_TAB);
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
 										String.valueOf(font.getStringWidth(tabBullet) / 1000 * getFontSize())));
 							} catch (IOException e) {
@@ -241,19 +265,22 @@ public class Paragraph {
 					}
 					// wrapping at last wrap point
 					if (listElement) {
-						if (orderList) {
-							String orderingNumber = String.valueOf(orderListElement) + ". ";
-							String tab = String.valueOf(indentLevel(DEFAULT_TAB));
-							String orderingNumberAndTab = orderingNumber + tab;
+						if(!getAlign().equals(HorizontalAlignment.LEFT)) {
+							listLevel = 0;
+						}
+						if (numberOfOrderedLists>0) {
+							String tab = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) : indentLevel(DEFAULT_TAB);
+							String orderingNumber = stack.isEmpty() ? String.valueOf(orderListElement) + "." : stack.peek().getValue() + "." + String.valueOf(orderListElement-1) + ".";
 							try {
-								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING, String
-										.valueOf(font.getStringWidth(orderingNumberAndTab) / 1000 * getFontSize())));
+								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
+										String.valueOf(font.getStringWidth(tab+orderingNumber) / 1000 * getFontSize())));
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
 						} else {
 							try {
-								String tabBullet = indentLevel(DEFAULT_TAB_AND_BULLET);
+								// if it's not left aligned then ignore list and list element and deal with it as normal text where <li> mimic <br> behavior
+								String tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(BULLET_SPACE)  : indentLevel(DEFAULT_TAB);
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
 										String.valueOf(font.getStringWidth(tabBullet) / 1000 * getFontSize())));
 							} catch (IOException e) {
@@ -279,8 +306,12 @@ public class Paragraph {
 					lineCounter++;
 					// wrapping at last wrap point
 					if (listElement) {
-						if (orderList) {
-							String orderingNumber = String.valueOf(orderListElement) + ". ";
+						if(!getAlign().equals(HorizontalAlignment.LEFT)) {
+							listLevel = 0;
+						}
+						if (numberOfOrderedLists>0) {
+//							String orderingNumber = String.valueOf(orderListElement) + ". ";
+							String orderingNumber = stack.isEmpty() ? String.valueOf("1") + "." : stack.pop().getValue() + ". ";
 							String tab = String.valueOf(indentLevel(DEFAULT_TAB));
 							String orderingNumberAndTab = orderingNumber + tab;
 							try {
@@ -291,8 +322,8 @@ public class Paragraph {
 							}
 						} else {
 							try {
-								// tab + bullet
-								String tabBullet = indentLevel(DEFAULT_TAB_AND_BULLET);
+								// if it's not left aligned then ignore list and list element and deal with it as normal text where <li> mimic <br> behaviour
+								String tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(DEFAULT_TAB_AND_BULLET) : indentLevel(DEFAULT_TAB);
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
 										String.valueOf(font.getStringWidth(tabBullet) / 1000 * getFontSize())));
 							} catch (IOException e) {
@@ -312,22 +343,31 @@ public class Paragraph {
 						lineCounter++;
 					}
 				} else if (isListElement(token)) {
+					if(!getAlign().equals(HorizontalAlignment.LEFT)) {
+						listLevel = 0;
+					}
 					listElement = true;
 					// token padding, token bullet
 					try {
-						// you always go one tab ahead
-						String tab = indentLevel(DEFAULT_TAB);
-						//						sinceLastWrapPoint.push(currentFont, fontSize, new Token(TokenType.PADDING, String.valueOf(font.getStringWidth(tab) / 1000 * getFontSize())));
+						// if it's not left aligned then ignore list and list element and deal with it as normal text where <li> mimic <br> behaviour
+						String tab = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) : indentLevel(DEFAULT_TAB);
 						textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
 								String.valueOf(font.getStringWidth(tab) / 1000 * getFontSize())));
-						if (orderList) {
+						if (numberOfOrderedLists>0) {
 							// if it's ordering list then move depending on your: ordering number + ". "
-							String orderingNumber = String.valueOf(orderListElement) + ". ";
+							String orderingNumber;
+							if(listLevel > 1){
+								orderingNumber = stack.peek().getValue() + String.valueOf(orderListElement) + ". "; 
+							} else {
+								orderingNumber = String.valueOf(orderListElement) + ". ";
+							}
 							textInLine.push(currentFont, fontSize, new Token(TokenType.ORDERING, orderingNumber));
 							orderListElement++;
 						} else {
-							// if it's unordered list then just move by bullet character
-							textInLine.push(currentFont, fontSize, new Token(TokenType.BULLET, " "));
+							// if it's unordered list then just move by bullet character (take care of alignment!)
+							if(getAlign().equals(HorizontalAlignment.LEFT)){
+								textInLine.push(currentFont, fontSize, new Token(TokenType.BULLET, " "));
+							} 
 						}
 					} catch (IOException e) {
 						e.printStackTrace();
@@ -335,7 +375,6 @@ public class Paragraph {
 				} else {
 					// wrapping at this must-have wrap point
 					textInLine.push(sinceLastWrapPoint);
-					// this is our line
 					result.add(textInLine.trimmedText());
 					lineWidths.put(lineCounter, textInLine.trimmedWidth());
 					mapLineTokens.put(lineCounter, textInLine.tokens());
@@ -346,8 +385,6 @@ public class Paragraph {
 				break;
 			case TEXT:
 				try {
-//					sinceLastWrapPoint.push(currentFont, fontSize, token);
-
 					String word = token.getData();
 					if(font.getStringWidth(word) / 1000f * fontSize > width && width > font.getAverageFontWidth() / 1000f * fontSize) {
 						// you need to check if you have already something in your line 

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -483,7 +483,7 @@ public abstract class Table<T extends PDPage> {
 				// new line
 				float lineStartX = cursorX;
 				float lineStartY = cursorY;
-
+				
 				// if it is head row or if it is header cell then please use bold font
 				if (row.equals(header) || cell.isHeaderCell()) {
 					this.tableContentStream.setFont(cell.getParagraph().getFont(true, false), cell.getFontSize());
@@ -573,6 +573,10 @@ public abstract class Table<T extends PDPage> {
 							}
 							break;
 						case BULLET:
+							// if cell is not left aligned then don't draw the bullet
+							if(!cell.getAlign().equals(HorizontalAlignment.LEFT)){
+								continue;
+							}
 							if (cell.isTextRotated()) {
 								// move cursorX up because bullet needs to be in the middle of font height
 								cursorX += FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;

--- a/src/test/java/be/quodlibet/boxable/TableTest.java
+++ b/src/test/java/be/quodlibet/boxable/TableTest.java
@@ -860,6 +860,40 @@ public class TableTest {
 		doc.save(file);
 		doc.close();
 	}
+    
+    @Test
+    public void IncorrectHTMLListNesting() throws IOException {
+
+        //Set margins
+        float margin = 10;
+
+        //Initialize Document
+        PDDocument doc = new PDDocument();
+        PDPage page = addNewPage(doc);
+
+        //Initialize table
+        float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
+        float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
+        boolean drawContent = true;
+        boolean drawLines = true;
+        float yStart = yStartNewPage;
+        float bottomMargin = 70;
+        BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
+                drawContent);
+
+        //Create Header row
+        Row<PDPage> row = table.createRow(15f);
+        Cell<PDPage> cell = row.createCell((100 / 3f), "<ol><li>a</li><ol><li>b1</li><li>b2</li><ol><li>c1</li><li>c2 hello hello hello hello hello hello hello hello hello hello hello </li><li>c3</li><li>c4 hello hello hello hello hello hello hello hello hello hello</li></ol><li>b3</li></ol><li>hello</li><li>hello</li><li>hello</li><li>hello</li><li>hello</li></ol>", HorizontalAlignment.get("left"), VerticalAlignment.get("top"));
+        Cell<PDPage> cell2 = row.createCell((100 / 3f), "<ul><li>a</li><ul><li>b1</li><li>b2</li><ul><li>c1</li><li>c2 hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello </li><li>c3</li><li>c4</li></ul><li>b3</li></ul><li>hello</li><li>hello</li><li>hello</li><li>hello</li></ul>", HorizontalAlignment.get("left"), VerticalAlignment.get("top"));
+        table.draw();
+
+        //Save the document
+        File file = new File("target/ListNesting.pdf");
+        System.out.println("Sample file saved at : " + file.getAbsolutePath());
+        Files.createParentDirs(file);
+        doc.save(file);
+        doc.close();
+    }
 
 	private static PDPage addNewPage(PDDocument doc) {
 		PDPage page = new PDPage();


### PR DESCRIPTION
Finally I find time for implementation of ordered lists ( #66 ) :smile: I also added a test case `IncorrectHTMLListNesting()` for this purpose. I must admit, I didn't play much with corner cases (e.g nested `<li>` elements and etc ...) so it would be good if can someone can test this bugfix with his example list or make some extra corner cases where output is not like expected.

Test case 

``` xml
// first cell with ordered list
<ol>
    <li>a</li>
    <ol>
        <li>b1</li>
        <li>b2</li><
        <ol>
            <li>c1</li><
            <li>c2 hello hello hello hello hello hello hello hello hello hello hello </li>
            <li>c3</li><
            <li>c4 hello hello hello hello hello hello hello hello hello hello</li>
        </ol>
        <li>b3</li>
    </ol>
    <li>hello</li>
    <li>hello</li>
    <li>hello</li>
    <li>hello</li>
    <li>hello</li>
</ol>
--------------------------------------------------------------------------------
// second cell with unordered list
<ul>
    <li>a</li>
    <ul>
        <li>b1</li>
        <li>b2</li>
        <ul>
            <li>c1</li>
            <li>c2 hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello </li>
            <li>c3</li>
            <li>c4</li>
        </ul>
        <li>b3</li>
    </ul>
    <li>hello</li>
    <li>hello</li>
    <li>hello</li>
    <li>hello</li>
</ul>
```

Output:
[OrderedListNesting.pdf](https://github.com/dhorions/boxable/files/529382/OrderedListNesting.pdf)
