### PR TITLE
Table.drawRow(Row) infinite loop fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
-task wrapper(type: Wrapper) {
-	gradleVersion = '2.13'
+wrapper {
+	gradleVersion = '5.2.1'
 }
 
 apply plugin: 'java'
@@ -26,11 +26,11 @@ repositories {
 }
 
 dependencies {
-	compile 'org.apache.pdfbox:pdfbox:2.0.3'
-	compile 'org.slf4j:slf4j-api:1.7.21'
-	compile 'com.google.guava:guava:20.0'
-	compile 'org.apache.commons:commons-csv:1.4'
-	compile group: 'org.jsoup', name: 'jsoup', version: '1.9.2'
+	compile 'org.apache.commons:commons-csv:1.7'
+	compile 'org.apache.pdfbox:pdfbox:2.0.16'
+	compile 'com.google.guava:guava:28.0-jre'
+	compile 'org.jsoup:jsoup:1.12.1'
+	compile 'org.slf4j:slf4j-api:1.8.0-beta4'
+	testCompile 'commons-io:commons-io:2.6'
 	testCompile 'junit:junit:4.12'
-	testCompile 'commons-io:commons-io:2.4'
 }

--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -744,4 +744,8 @@ public class Cell<T extends PDPage> {
 		this.lineSpacing = lineSpacing;
 	}
 
+	@Override
+	public String toString() {
+		return String.format("%s {%s}", getClass().getSimpleName(), text);
+	}
 }

--- a/src/main/java/be/quodlibet/boxable/Row.java
+++ b/src/main/java/be/quodlibet/boxable/Row.java
@@ -285,4 +285,9 @@ public class Row<T extends PDPage> {
 	public void setLineSpacing(float lineSpacing) {
 		this.lineSpacing = lineSpacing;
 	}
+
+	@Override
+	public String toString() {
+		return String.format("%s { %s }", getClass().getSimpleName(), cells);
+	}
 }

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -283,7 +283,7 @@ public abstract class Table<T extends PDPage> {
 			row.removeAllBorders();
 		}
 
-		if (isEndOfPage(row)) {
+		if (isEndOfPage(row) && !header.contains(row)) {
 
 			// Draw line at bottom of table
 			endTable();


### PR DESCRIPTION
When the header rows would be drawn below the bottom margin of the page, `Table.drawRow(Row)` will start an infinite loop resulting in:

```java
java.lang.StackOverflowError
	at java.util.regex.Pattern.atom(Pattern.java:2200)
	at java.util.regex.Pattern.sequence(Pattern.java:2081)
	at java.util.regex.Pattern.expr(Pattern.java:1998)
	at java.util.regex.Pattern.group0(Pattern.java:2860)
	at java.util.regex.Pattern.sequence(Pattern.java:2053)
	at java.util.regex.Pattern.expr(Pattern.java:1998)
	at java.util.regex.Pattern.compile(Pattern.java:1698)
	at java.util.regex.Pattern.<init>(Pattern.java:1351)
	at java.util.regex.Pattern.compile(Pattern.java:1028)
	at java.lang.String.split(String.java:2380)
	at java.lang.String.split(String.java:2422)
	at be.quodlibet.boxable.Paragraph$1.getLines(Paragraph.java:59)
	at be.quodlibet.boxable.text.Tokenizer.tokenize(Tokenizer.java:16)
	at be.quodlibet.boxable.Paragraph.getLines(Paragraph.java:98)
	at be.quodlibet.boxable.Paragraph.getHeight(Paragraph.java:599)
	at be.quodlibet.boxable.Cell.getTextHeight(Cell.java:402)
	at be.quodlibet.boxable.Cell.getCellHeight(Cell.java:376)
	at be.quodlibet.boxable.Row.getHeight(Row.java:214)
	at be.quodlibet.boxable.Table.isEndOfPage(Table.java:841)
	at be.quodlibet.boxable.Table.drawRow(Table.java:287)
	at be.quodlibet.boxable.Table.drawRow(Table.java:298)
	at be.quodlibet.boxable.Table.drawRow(Table.java:298)
	at be.quodlibet.boxable.Table.drawRow(Table.java:298)
        ...
```