### PR TITLE
Performance enhancements

### DIFF
--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -28,7 +28,7 @@ import be.quodlibet.boxable.utils.PDStreamUtils;
 public class Paragraph {
 
 	private float width = 500;
-	private String text;
+	private final String text;
 	private float fontSize;
 	private PDFont font = PDType1Font.HELVETICA;
 	private PDFont fontBold = PDType1Font.HELVETICA_BOLD;
@@ -48,6 +48,7 @@ public class Paragraph {
 	private final Map<Integer, Float> lineWidths = new HashMap<>();
 	private Map<Integer, List<Token>> mapLineTokens = new LinkedHashMap<>();
 	private float maxLineWidth = Integer.MIN_VALUE;
+	private List<Token> tokens;
 
 	public Paragraph(String text, PDFont font, float fontSize, float width, final HorizontalAlignment align) {
 		this(text, font, fontSize, width, align, null);
@@ -95,7 +96,11 @@ public class Paragraph {
 
 	public List<String> getLines() {
 		final List<String> result = new ArrayList<>();
-		final List<Token> tokens = Tokenizer.tokenize(text, wrappingFunction);
+
+		// text and wrappingFunction are immutable, so we only ever need to compute tokens once
+		if (tokens == null) {
+			tokens = Tokenizer.tokenize(text, wrappingFunction);
+		}
 
 		int lineCounter = 0;
 		boolean italic = false;

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -424,13 +424,13 @@ public class Paragraph {
 			case TEXT:
 				try {
 					String word = token.getData();
-					if(font.getStringWidth(word) / 1000f * fontSize > width && width > font.getAverageFontWidth() / 1000f * fontSize) {
+					if(currentFont.getStringWidth(word) / 1000f * fontSize > width && width > currentFont.getAverageFontWidth() / 1000f * fontSize) {
 						// you need to check if you have already something in your line
 						boolean alreadyTextInLine = false;
 						if(textInLine.trimmedWidth()>0){
 							alreadyTextInLine = true;
 						}
-						while (font.getStringWidth(word) / 1000f * fontSize > width) {
+						while (currentFont.getStringWidth(word) / 1000f * fontSize > width) {
 						float width = 0;
 						float firstPartWordWidth = 0;
 						float restOfTheWordWidth = 0;
@@ -440,7 +440,7 @@ public class Paragraph {
 						for (int i = 0; i < lastTextToken.length(); i++) {
 							char c = lastTextToken.charAt(i);
 							try {
-								width += (font.getStringWidth("" + c) / 1000f * fontSize);
+								width += (currentFont.getStringWidth("" + c) / 1000f * fontSize);
 							} catch (IOException e) {
 								e.printStackTrace();
 							}

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
-import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import be.quodlibet.boxable.utils.PageContentStreamOptimized;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 
@@ -560,7 +560,7 @@ public class Paragraph {
 		}
 	}
 
-	public float write(final PDPageContentStream stream, float cursorX, float cursorY) {
+	public float write(final PageContentStreamOptimized stream, float cursorX, float cursorY) {
 		if (drawDebug) {
 			PDStreamUtils.rectFontMetrics(stream, cursorX, cursorY, font, fontSize);
 

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -442,31 +442,31 @@ public class Paragraph {
 						for (int i = 0; i < lastTextToken.length(); i++) {
 							char c = lastTextToken.charAt(i);
 							try {
-								width += (currentFont.getStringWidth("" + c) / 1000f * fontSize);
+								width += (currentFont.getStringWidth(String.valueOf(c)) / 1000f * fontSize);
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
 							if(alreadyTextInLine){
 								if (width < this.width - textInLine.trimmedWidth()) {
-									firstPartOfWord.append("" + c);
+									firstPartOfWord.append(c);
 									firstPartWordWidth = Math.max(width, firstPartWordWidth);
 								} else {
-									restOfTheWord.append("" + c);
+									restOfTheWord.append(c);
 									restOfTheWordWidth = Math.max(width, restOfTheWordWidth);
 								}
 							} else {
 								if (width < this.width) {
-									firstPartOfWord.append("" + c);
+									firstPartOfWord.append(c);
 									firstPartWordWidth = Math.max(width, firstPartWordWidth);
 								} else {
 									if(i==0){
-										firstPartOfWord.append("" + c);
+										firstPartOfWord.append(c);
 										for (int j = 1; j< lastTextToken.length(); j++){
-											restOfTheWord.append("" + lastTextToken.charAt(j));
+											restOfTheWord.append(lastTextToken.charAt(j));
 										}
 										break;
 									} else {
-										restOfTheWord.append("" + c);
+										restOfTheWord.append(c);
 										restOfTheWordWidth = Math.max(width, restOfTheWordWidth);
 
 									}

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -55,6 +55,8 @@ public class Paragraph {
 		this(text, font, fontSize, width, align, null);
 	}
 
+	// This function exists only to preserve backwards compatibility for
+	// the getWrappingFunction() method; it has been replaced with a faster implementation in the Tokenizer
 	private static final WrappingFunction DEFAULT_WRAP_FUNC = new WrappingFunction() {
 		@Override
 		public String[] getLines(String t) {
@@ -95,7 +97,7 @@ public class Paragraph {
 		this.width = width;
 		this.textType = textType;
 		this.setAlign(align);
-		this.wrappingFunction = wrappingFunction == null ? DEFAULT_WRAP_FUNC : wrappingFunction;
+		this.wrappingFunction = wrappingFunction;
 		this.lineSpacing = lineSpacing;
 	}
 
@@ -734,7 +736,7 @@ public class Paragraph {
 	}
 
 	public WrappingFunction getWrappingFunction() {
-		return wrappingFunction;
+		return wrappingFunction == null ? DEFAULT_WRAP_FUNC : wrappingFunction;
 	}
 
 	public float getMaxLineWidth() {

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -50,6 +50,7 @@ public class Paragraph {
 	private float maxLineWidth = Integer.MIN_VALUE;
 	private List<Token> tokens;
 	private List<String> lines;
+	private Float spaceWidth;
 
 	public Paragraph(String text, PDFont font, float fontSize, float width, final HorizontalAlignment align) {
 		this(text, font, fontSize, width, align, null);
@@ -213,11 +214,11 @@ public class Paragraph {
 						if (numberOfOrderedLists>0) {
 							String orderingNumber = stack.isEmpty() ? String.valueOf(orderListElement) + "." : stack.pop().getValue() + ".";
 							stack.add(new HTMLListNode(orderListElement, orderingNumber));
-							String tab = String.valueOf(indentLevel(DEFAULT_TAB));
-							String orderingNumberAndTab = orderingNumber + tab;
 							try {
+								float tab = indentLevel(DEFAULT_TAB);
+								float orderingNumberAndTab = font.getStringWidth(orderingNumber) + tab;
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING, String
-										.valueOf(font.getStringWidth(orderingNumberAndTab) / 1000 * getFontSize())));
+										.valueOf(orderingNumberAndTab / 1000 * getFontSize())));
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
@@ -225,9 +226,9 @@ public class Paragraph {
 						} else {
 							try {
 								// if it's not left aligned then ignore list and list element and deal with it as normal text where <li> mimic <br> behaviour
-								String tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(DEFAULT_TAB_AND_BULLET) : indentLevel(DEFAULT_TAB);
+								float tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0) + DEFAULT_TAB_AND_BULLET) : indentLevel(DEFAULT_TAB);
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
-										String.valueOf(font.getStringWidth(tabBullet) / 1000 * getFontSize())));
+										String.valueOf(tabBullet / 1000 * getFontSize())));
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
@@ -286,20 +287,20 @@ public class Paragraph {
 					// wrapping at last wrap point
 					if (listElement) {
 						if (numberOfOrderedLists>0) {
-							String tab = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(DEFAULT_TAB) : indentLevel(DEFAULT_TAB);
-							String orderingNumber = stack.isEmpty() ? String.valueOf(orderListElement) + "." : stack.peek().getValue() + "." + String.valueOf(orderListElement-1) + ".";
 							try {
+								float tab = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0) + DEFAULT_TAB) : indentLevel(DEFAULT_TAB);
+								String orderingNumber = stack.isEmpty() ? String.valueOf(orderListElement) + "." : stack.peek().getValue() + "." + String.valueOf(orderListElement-1) + ".";
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
-										String.valueOf(font.getStringWidth(tab+orderingNumber) / 1000 * getFontSize())));
+										String.valueOf((tab + font.getStringWidth(orderingNumber)) / 1000 * getFontSize())));
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
 						} else {
 							try {
 								// if it's not left aligned then ignore list and list element and deal with it as normal text where <li> mimic <br> behavior
-								String tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(DEFAULT_TAB_AND_BULLET)  : indentLevel(DEFAULT_TAB);
+								float tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0) + DEFAULT_TAB_AND_BULLET)  : indentLevel(DEFAULT_TAB);
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
-										String.valueOf(font.getStringWidth(tabBullet) / 1000 * getFontSize())));
+										String.valueOf(tabBullet / 1000 * getFontSize())));
 							} catch (IOException e) {
 								// TODO Auto-generated catch block
 								e.printStackTrace();
@@ -329,20 +330,20 @@ public class Paragraph {
 						if (numberOfOrderedLists>0) {
 //							String orderingNumber = String.valueOf(orderListElement) + ". ";
 							String orderingNumber = stack.isEmpty() ? String.valueOf("1") + "." : stack.pop().getValue() + ". ";
-							String tab = String.valueOf(indentLevel(DEFAULT_TAB));
-							String orderingNumberAndTab = orderingNumber + tab;
 							try {
+								float tab = indentLevel(DEFAULT_TAB);
+								float orderingNumberAndTab = font.getStringWidth(orderingNumber) + tab;
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING, String
-										.valueOf(font.getStringWidth(orderingNumberAndTab) / 1000 * getFontSize())));
+										.valueOf(orderingNumberAndTab / 1000 * getFontSize())));
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
 						} else {
 							try {
 								// if it's not left aligned then ignore list and list element and deal with it as normal text where <li> mimic <br> behaviour
-								String tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(DEFAULT_TAB_AND_BULLET) : indentLevel(DEFAULT_TAB);
+								float tabBullet = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0) + DEFAULT_TAB_AND_BULLET) : indentLevel(DEFAULT_TAB);
 								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
-										String.valueOf(font.getStringWidth(tabBullet) / 1000 * getFontSize())));
+										String.valueOf(tabBullet / 1000 * getFontSize())));
 							} catch (IOException e) {
 								e.printStackTrace();
 							}
@@ -364,9 +365,9 @@ public class Paragraph {
 					// token padding, token bullet
 					try {
 						// if it's not left aligned then ignore list and list element and deal with it as normal text where <li> mimic <br> behaviour
-						String tab = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(DEFAULT_TAB) : indentLevel(DEFAULT_TAB);
+						float tab = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0) + DEFAULT_TAB) : indentLevel(DEFAULT_TAB);
 						textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
-								String.valueOf(font.getStringWidth(tab) / 1000 * getFontSize())));
+								String.valueOf(tab / 1000 * getFontSize())));
 						if (numberOfOrderedLists>0) {
 							// if it's ordering list then move depending on your: ordering number + ". "
 							String orderingNumber;
@@ -397,7 +398,7 @@ public class Paragraph {
 						// preserve current indent
 						try {
 							if (numberOfOrderedLists>0) {
-								String tab = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) : indentLevel(DEFAULT_TAB);
+								float tab = getAlign().equals(HorizontalAlignment.LEFT) ? indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) : indentLevel(DEFAULT_TAB);
 								// if it's ordering list then move depending on your: ordering number + ". "
 								String orderingNumber;
 								if(listLevel > 1){
@@ -405,14 +406,14 @@ public class Paragraph {
 								} else {
 									orderingNumber = String.valueOf(orderListElement) + ". ";
 								}
-								String tabAndOrderingNumber = tab + orderingNumber;
-								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING, String.valueOf(font.getStringWidth(tabAndOrderingNumber) / 1000 * getFontSize())));
+								float tabAndOrderingNumber = tab + font.getStringWidth(orderingNumber);
+								textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING, String.valueOf(tabAndOrderingNumber / 1000 * getFontSize())));
 								orderListElement++;
 							} else {
 								if(getAlign().equals(HorizontalAlignment.LEFT)){
-									String tab = indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0)) + indentLevel(DEFAULT_TAB) + indentLevel(BULLET_SPACE);
+									float tab = indentLevel(DEFAULT_TAB*Math.max(listLevel - 1, 0) + DEFAULT_TAB + BULLET_SPACE);
 									textInLine.push(currentFont, fontSize, new Token(TokenType.PADDING,
-											String.valueOf(font.getStringWidth(tab) / 1000 * getFontSize())));
+											String.valueOf(tab / 1000 * getFontSize())));
 								}
 							}
 						} catch (IOException e) {
@@ -533,17 +534,11 @@ public class Paragraph {
 		return "ul".equals(token.getData()) || "ol".equals(token.getData());
 	}
 
-	private static String indentLevel(int numberOfSpaces) {
-		// String builder is efficient at concatenating strings together
-		StringBuilder sb = new StringBuilder();
-
-		// Loop as many times as specified; each time add a space to the string
-		for (int i = 0; i < numberOfSpaces; i++) {
-			sb.append(" ");
+	private float indentLevel(int numberOfSpaces) throws IOException {
+		if (spaceWidth == null) {
+			spaceWidth = font.getSpaceWidth();
 		}
-
-		// Return the string
-		return sb.toString();
+		return numberOfSpaces * spaceWidth;
 	}
 
 	public PDFont getFont(boolean isBold, boolean isItalic) {
@@ -660,6 +655,7 @@ public class Paragraph {
 	@Deprecated
 	public Paragraph withFont(PDFont font, int fontSize) {
 		invalidateLineWrapping();
+		this.spaceWidth = null;
 		this.font = font;
 		this.fontSize = fontSize;
 		return this;

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -424,13 +424,14 @@ public class Paragraph {
 			case TEXT:
 				try {
 					String word = token.getData();
-					if(currentFont.getStringWidth(word) / 1000f * fontSize > width && width > currentFont.getAverageFontWidth() / 1000f * fontSize) {
+					float wordWidth = token.getWidth(currentFont);
+					if(wordWidth / 1000f * fontSize > width && width > font.getAverageFontWidth() / 1000f * fontSize) {
 						// you need to check if you have already something in your line
 						boolean alreadyTextInLine = false;
 						if(textInLine.trimmedWidth()>0){
 							alreadyTextInLine = true;
 						}
-						while (currentFont.getStringWidth(word) / 1000f * fontSize > width) {
+						while (wordWidth / 1000f * fontSize > width) {
 						float width = 0;
 						float firstPartWordWidth = 0;
 						float restOfTheWordWidth = 0;
@@ -484,6 +485,7 @@ public class Paragraph {
 						textInLine.reset();
 						lineCounter++;
 						word = restOfTheWord.toString();
+						wordWidth = currentFont.getStringWidth(word);
 						}
 						sinceLastWrapPoint.push(currentFont, fontSize, new Token(TokenType.TEXT, word));
 					} else {

--- a/src/main/java/be/quodlibet/boxable/Paragraph.java
+++ b/src/main/java/be/quodlibet/boxable/Paragraph.java
@@ -375,11 +375,11 @@ public class Paragraph {
 							} else {
 								orderingNumber = String.valueOf(orderListElement) + ". ";
 							}
-							textInLine.push(currentFont, fontSize, new Token(TokenType.ORDERING, orderingNumber));
+							textInLine.push(currentFont, fontSize, Token.text(TokenType.ORDERING, orderingNumber));
 							orderListElement++;
 						} else {
 							// if it's unordered list then just move by bullet character (take care of alignment!)
-							textInLine.push(currentFont, fontSize, new Token(TokenType.BULLET, " "));
+							textInLine.push(currentFont, fontSize, Token.text(TokenType.BULLET, " "));
 						}
 					} catch (IOException e) {
 						e.printStackTrace();
@@ -475,7 +475,7 @@ public class Paragraph {
 						// reset
 						alreadyTextInLine = false;
 						sinceLastWrapPoint.push(currentFont, fontSize,
-								new Token(TokenType.TEXT, firstPartOfWord.toString()));
+								Token.text(TokenType.TEXT, firstPartOfWord.toString()));
 						textInLine.push(sinceLastWrapPoint);
 						// this is our line
 						result.add(textInLine.trimmedText());
@@ -487,7 +487,7 @@ public class Paragraph {
 						word = restOfTheWord.toString();
 						wordWidth = currentFont.getStringWidth(word);
 						}
-						sinceLastWrapPoint.push(currentFont, fontSize, new Token(TokenType.TEXT, word));
+						sinceLastWrapPoint.push(currentFont, fontSize, Token.text(TokenType.TEXT, word));
 					} else {
 						sinceLastWrapPoint.push(currentFont, fontSize, token);
 					}

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -662,7 +662,7 @@ public abstract class Table<T extends PDPage> {
 							}
 							break;
 						case BULLET:
-                            float widthOfSpace = currentFont.getStringWidth(" ");
+                            float widthOfSpace = currentFont.getSpaceWidth();
                             float halfHeight = FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;
 							if (cell.isTextRotated()) {
 								PDStreamUtils.rect(tableContentStream, cursorX + halfHeight, cursorY,

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -662,33 +662,24 @@ public abstract class Table<T extends PDPage> {
 							}
 							break;
 						case BULLET:
-
+                            float widthOfSpace = currentFont.getStringWidth(" ");
+                            float halfHeight = FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;
 							if (cell.isTextRotated()) {
-								// move cursorX up because bullet needs to be in
-								// the middle of font height
-								cursorX += FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;
-								PDStreamUtils.rect(tableContentStream, cursorX, cursorY,
+								PDStreamUtils.rect(tableContentStream, cursorX + halfHeight, cursorY,
 										token.getWidth(currentFont) / 1000 * cell.getFontSize(),
-										currentFont.getStringWidth(" ") / 1000 * cell.getFontSize(),
+                                        widthOfSpace / 1000 * cell.getFontSize(),
 										cell.getTextColor());
 								// move cursorY for two characters (one for
 								// bullet, one for space after bullet)
-								cursorY += 2 * currentFont.getStringWidth(" ") / 1000 * cell.getFontSize();
-								// return cursorY to his original place
-								cursorX -= FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;
+								cursorY += 2 * widthOfSpace / 1000 * cell.getFontSize();
 							} else {
-								// move cursorY up because bullet needs to be in
-								// the middle of font height
-								cursorY += FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;
-								PDStreamUtils.rect(tableContentStream, cursorX, cursorY,
+								PDStreamUtils.rect(tableContentStream, cursorX, cursorY + halfHeight,
 										token.getWidth(currentFont) / 1000 * cell.getFontSize(),
-										currentFont.getStringWidth(" ") / 1000 * cell.getFontSize(),
+                                        widthOfSpace / 1000 * cell.getFontSize(),
 										cell.getTextColor());
 								// move cursorX for two characters (one for
 								// bullet, one for space after bullet)
-								cursorX += 2 * currentFont.getStringWidth(" ") / 1000 * cell.getFontSize();
-								// return cursorY to his original place
-								cursorY -= FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;
+								cursorX += 2 * widthOfSpace / 1000 * cell.getFontSize();
 							}
 							break;
 						case TEXT:

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -7,7 +7,6 @@ package be.quodlibet.boxable;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.awt.Color;
-import java.awt.geom.AffineTransform;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -22,7 +21,6 @@ import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageXYZDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
-import org.apache.pdfbox.util.Matrix;
 
 import be.quodlibet.boxable.line.LineStyle;
 import be.quodlibet.boxable.page.PageProvider;
@@ -581,6 +579,8 @@ public abstract class Table<T extends PDPage> {
 				int italicCounter = 0;
 				int boldCounter = 0;
 
+				this.tableContentStream.setRotated(cell.isTextRotated());
+
 				// print all lines of the cell
 				for (Map.Entry<Integer, List<Token>> entry : cell.getParagraph().getMapLineTokens().entrySet()) {
 
@@ -642,11 +642,6 @@ public abstract class Table<T extends PDPage> {
 							currentFont = cell.getParagraph().getFont(boldCounter > 0, italicCounter > 0);
 							this.tableContentStream.setFont(currentFont, cell.getFontSize());
 							if (cell.isTextRotated()) {
-								final AffineTransform transform = AffineTransform.getTranslateInstance(cursorX,
-										cursorY);
-								transform.concatenate(AffineTransform.getRotateInstance(Math.PI * 0.5f));
-								transform.concatenate(AffineTransform.getTranslateInstance(-cursorX, -cursorY));
-								tableContentStream.setTextMatrix(new Matrix(transform));
 								tableContentStream.newLineAt(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
 								cursorY += token.getWidth(currentFont) / 1000 * cell.getFontSize();
@@ -681,11 +676,6 @@ public abstract class Table<T extends PDPage> {
 							currentFont = cell.getParagraph().getFont(boldCounter > 0, italicCounter > 0);
 							this.tableContentStream.setFont(currentFont, cell.getFontSize());
 							if (cell.isTextRotated()) {
-								final AffineTransform transform = AffineTransform.getTranslateInstance(cursorX,
-										cursorY);
-								transform.concatenate(AffineTransform.getRotateInstance(Math.PI * 0.5f));
-								transform.concatenate(AffineTransform.getTranslateInstance(-cursorX, -cursorY));
-								tableContentStream.setTextMatrix(new Matrix(transform));
 								tableContentStream.newLineAt(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
 								cursorY += token.getWidth(currentFont) / 1000 * cell.getFontSize();

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import be.quodlibet.boxable.utils.PageContentStreamOptimized;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -36,7 +37,7 @@ public abstract class Table<T extends PDPage> {
 	private float margin;
 
 	private T currentPage;
-	private PDPageContentStream tableContentStream;
+	private PageContentStreamOptimized tableContentStream;
 	private List<PDOutlineItem> bookmarks;
 	private List<Row<T>> header = new ArrayList<>();
 	private List<Row<T>> rows = new ArrayList<>();
@@ -187,7 +188,7 @@ public abstract class Table<T extends PDPage> {
 			// "row"
 			yStart -= height;
 		} else {
-			PDPageContentStream articleTitle = createPdPageContentStream();
+			PageContentStreamOptimized articleTitle = createPdPageContentStream();
 			Paragraph paragraph = new Paragraph(title, font, fontSize, tableWidth, HorizontalAlignment.get(alignment),
 					wrappingFunction);
 			paragraph.setDrawDebug(drawDebug);
@@ -367,8 +368,10 @@ public abstract class Table<T extends PDPage> {
 				"You either have to provide a " + PageProvider.class.getCanonicalName() + " or override this method");
 	}
 
-	private PDPageContentStream createPdPageContentStream() throws IOException {
-		return new PDPageContentStream(getDocument(), getCurrentPage(), true, true);
+	private PageContentStreamOptimized createPdPageContentStream() throws IOException {
+		return new PageContentStreamOptimized(
+				new PDPageContentStream(getDocument(), getCurrentPage(),
+						PDPageContentStream.AppendMode.APPEND, true));
 	}
 
 	private void drawCellContent(Row<T> row, float rowHeight) throws IOException {

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -649,13 +649,13 @@ public abstract class Table<T extends PDPage> {
 								this.tableContentStream.showText(token.getData());
 								this.tableContentStream.endText();
 								this.tableContentStream.closePath();
-								cursorY += currentFont.getStringWidth(token.getData()) / 1000 * cell.getFontSize();
+								cursorY += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							} else {
 								this.tableContentStream.newLineAtOffset(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
 								this.tableContentStream.endText();
 								this.tableContentStream.closePath();
-								cursorX += currentFont.getStringWidth(token.getData()) / 1000 * cell.getFontSize();
+								cursorX += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							}
 							break;
 						case BULLET:
@@ -665,7 +665,7 @@ public abstract class Table<T extends PDPage> {
 								// the middle of font height
 								cursorX += FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;
 								PDStreamUtils.rect(tableContentStream, cursorX, cursorY,
-										currentFont.getStringWidth(token.getData()) / 1000 * cell.getFontSize(),
+										token.getWidth(currentFont) / 1000 * cell.getFontSize(),
 										currentFont.getStringWidth(" ") / 1000 * cell.getFontSize(),
 										cell.getTextColor());
 								// move cursorY for two characters (one for
@@ -678,7 +678,7 @@ public abstract class Table<T extends PDPage> {
 								// the middle of font height
 								cursorY += FontUtils.getHeight(currentFont, cell.getFontSize()) / 2;
 								PDStreamUtils.rect(tableContentStream, cursorX, cursorY,
-										currentFont.getStringWidth(token.getData()) / 1000 * cell.getFontSize(),
+										token.getWidth(currentFont) / 1000 * cell.getFontSize(),
 										currentFont.getStringWidth(" ") / 1000 * cell.getFontSize(),
 										cell.getTextColor());
 								// move cursorX for two characters (one for
@@ -702,14 +702,14 @@ public abstract class Table<T extends PDPage> {
 								this.tableContentStream.showText(token.getData());
 								this.tableContentStream.endText();
 								this.tableContentStream.closePath();
-								cursorY += currentFont.getStringWidth(token.getData()) / 1000 * cell.getFontSize();
+								cursorY += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							} else {
 								try {
 									this.tableContentStream.newLineAtOffset(cursorX, cursorY);
 									this.tableContentStream.showText(token.getData());
 									this.tableContentStream.endText();
 									this.tableContentStream.closePath();
-									cursorX += currentFont.getStringWidth(token.getData()) / 1000 * cell.getFontSize();
+									cursorX += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 								} catch (IOException e) {
 									e.printStackTrace();
 								}

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -790,9 +790,6 @@ public abstract class Table<T extends PDPage> {
 
 			this.tableContentStream.addRect(xStart, yStart, cellWidth, height);
 			this.tableContentStream.fill();
-
-			// Reset NonStroking Color to default value
-			this.tableContentStream.setNonStrokingColor(Color.BLACK);
 		}
 	}
 

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -436,6 +436,7 @@ public abstract class Table<T extends PDPage> {
 				cursorX += cell.getLeftPadding() + (cell.getLeftBorder() == null ? 0 : cell.getLeftBorder().getWidth());
 				tableCell.setXPosition(cursorX);
 				tableCell.setYPosition(cursorY);
+				this.tableContentStream.endText();
 				tableCell.draw(currentPage);
 			} else {
 				// no text without font

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -639,7 +639,6 @@ public abstract class Table<T extends PDPage> {
 							cursorX += Float.parseFloat(token.getData());
 							break;
 						case ORDERING:
-							this.tableContentStream.beginText();
 							currentFont = cell.getParagraph().getFont(boldCounter > 0, italicCounter > 0);
 							this.tableContentStream.setFont(currentFont, cell.getFontSize());
 							if (cell.isTextRotated()) {
@@ -648,14 +647,12 @@ public abstract class Table<T extends PDPage> {
 								transform.concatenate(AffineTransform.getRotateInstance(Math.PI * 0.5f));
 								transform.concatenate(AffineTransform.getTranslateInstance(-cursorX, -cursorY));
 								tableContentStream.setTextMatrix(new Matrix(transform));
-								tableContentStream.newLineAtOffset(cursorX, cursorY);
+								tableContentStream.newLineAt(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
-								this.tableContentStream.endText();
 								cursorY += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							} else {
-								this.tableContentStream.newLineAtOffset(cursorX, cursorY);
+								this.tableContentStream.newLineAt(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
-								this.tableContentStream.endText();
 								cursorX += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							}
 							break;
@@ -681,7 +678,6 @@ public abstract class Table<T extends PDPage> {
 							}
 							break;
 						case TEXT:
-							this.tableContentStream.beginText();
 							currentFont = cell.getParagraph().getFont(boldCounter > 0, italicCounter > 0);
 							this.tableContentStream.setFont(currentFont, cell.getFontSize());
 							if (cell.isTextRotated()) {
@@ -690,15 +686,13 @@ public abstract class Table<T extends PDPage> {
 								transform.concatenate(AffineTransform.getRotateInstance(Math.PI * 0.5f));
 								transform.concatenate(AffineTransform.getTranslateInstance(-cursorX, -cursorY));
 								tableContentStream.setTextMatrix(new Matrix(transform));
-								tableContentStream.newLineAtOffset(cursorX, cursorY);
+								tableContentStream.newLineAt(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
-								this.tableContentStream.endText();
 								cursorY += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							} else {
 								try {
-									this.tableContentStream.newLineAtOffset(cursorX, cursorY);
+									this.tableContentStream.newLineAt(cursorX, cursorY);
 									this.tableContentStream.showText(token.getData());
-									this.tableContentStream.endText();
 									cursorX += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 								} catch (IOException e) {
 									e.printStackTrace();

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -651,13 +651,11 @@ public abstract class Table<T extends PDPage> {
 								tableContentStream.newLineAtOffset(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
 								this.tableContentStream.endText();
-								this.tableContentStream.closePath();
 								cursorY += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							} else {
 								this.tableContentStream.newLineAtOffset(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
 								this.tableContentStream.endText();
-								this.tableContentStream.closePath();
 								cursorX += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							}
 							break;
@@ -695,14 +693,12 @@ public abstract class Table<T extends PDPage> {
 								tableContentStream.newLineAtOffset(cursorX, cursorY);
 								this.tableContentStream.showText(token.getData());
 								this.tableContentStream.endText();
-								this.tableContentStream.closePath();
 								cursorY += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 							} else {
 								try {
 									this.tableContentStream.newLineAtOffset(cursorX, cursorY);
 									this.tableContentStream.showText(token.getData());
 									this.tableContentStream.endText();
-									this.tableContentStream.closePath();
 									cursorX += token.getWidth(currentFont) / 1000 * cell.getFontSize();
 								} catch (IOException e) {
 									e.printStackTrace();
@@ -786,7 +782,6 @@ public abstract class Table<T extends PDPage> {
 		tableContentStream.moveTo(xStart, yStart);
 		tableContentStream.lineTo(xEnd, yEnd);
 		tableContentStream.stroke();
-		tableContentStream.closePath();
 	}
 
 	private void fillCellColor(Cell<T> cell, float yStart, float xStart, float rowHeight, float cellWidth)
@@ -801,7 +796,6 @@ public abstract class Table<T extends PDPage> {
 
 			this.tableContentStream.addRect(xStart, yStart, cellWidth, height);
 			this.tableContentStream.fill();
-			this.tableContentStream.closePath();
 
 			// Reset NonStroking Color to default value
 			this.tableContentStream.setNonStrokingColor(Color.BLACK);

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -743,7 +743,7 @@ public abstract class Table<T extends PDPage> {
 		while (cellIterator.hasNext()) {
 			Cell<T> cell = cellIterator.next();
 
-			fillCellColor(cell, yStart, xStart, cellIterator);
+			fillCellColor(cell, yStart, xStart, rowHeight, cellIterator);
 
 			drawCellBorders(rowHeight, cell, xStart);
 
@@ -795,15 +795,15 @@ public abstract class Table<T extends PDPage> {
 		tableContentStream.closePath();
 	}
 
-	private void fillCellColor(Cell<T> cell, float yStart, float xStart, Iterator<Cell<T>> cellIterator)
+	private void fillCellColor(Cell<T> cell, float yStart, float xStart, float rowHeight, Iterator<Cell<T>> cellIterator)
 			throws IOException {
 
 		if (cell.getFillColor() != null) {
 			this.tableContentStream.setNonStrokingColor(cell.getFillColor());
 
 			// y start is bottom pos
-			yStart = yStart - cell.getHeight();
-			float height = cell.getHeight() - (cell.getTopBorder() == null ? 0 : cell.getTopBorder().getWidth());
+			yStart = yStart - rowHeight;
+			float height = rowHeight - (cell.getTopBorder() == null ? 0 : cell.getTopBorder().getWidth());
 
 			float cellWidth = getWidth(cell, cellIterator);
 			this.tableContentStream.addRect(xStart, yStart, cellWidth, height);

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -444,9 +444,6 @@ public abstract class Table<T extends PDPage> {
 					throw new IllegalArgumentException("Font is null on Cell=" + cell.getText());
 				}
 
-				// font settings
-				this.tableContentStream.setFont(cell.getFont(), cell.getFontSize());
-
 				if (cell.isTextRotated()) {
 					// debugging mode - drawing (default!) padding of rotated
 					// cells
@@ -570,11 +567,6 @@ public abstract class Table<T extends PDPage> {
 				float lineStartX = cursorX;
 				float lineStartY = cursorY;
 
-				// if it is head row or if it is header cell then please use
-				// bold font
-				if (row.equals(header) || cell.isHeaderCell()) {
-					this.tableContentStream.setFont(cell.getParagraph().getFont(true, false), cell.getFontSize());
-				}
 				this.tableContentStream.setNonStrokingColor(cell.getTextColor());
 
 				int italicCounter = 0;

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -743,11 +743,14 @@ public abstract class Table<T extends PDPage> {
 		while (cellIterator.hasNext()) {
 			Cell<T> cell = cellIterator.next();
 
-			fillCellColor(cell, yStart, xStart, rowHeight, cellIterator);
+			float cellWidth = cellIterator.hasNext()
+                    ? cell.getWidth()
+                    : this.width - (xStart - margin);
+			fillCellColor(cell, yStart, xStart, rowHeight, cellWidth);
 
 			drawCellBorders(rowHeight, cell, xStart);
 
-			xStart += getWidth(cell, cellIterator);
+			xStart += cellWidth;
 		}
 
 	}
@@ -795,7 +798,7 @@ public abstract class Table<T extends PDPage> {
 		tableContentStream.closePath();
 	}
 
-	private void fillCellColor(Cell<T> cell, float yStart, float xStart, float rowHeight, Iterator<Cell<T>> cellIterator)
+	private void fillCellColor(Cell<T> cell, float yStart, float xStart, float rowHeight, float cellWidth)
 			throws IOException {
 
 		if (cell.getFillColor() != null) {
@@ -805,7 +808,6 @@ public abstract class Table<T extends PDPage> {
 			yStart = yStart - rowHeight;
 			float height = rowHeight - (cell.getTopBorder() == null ? 0 : cell.getTopBorder().getWidth());
 
-			float cellWidth = getWidth(cell, cellIterator);
 			this.tableContentStream.addRect(xStart, yStart, cellWidth, height);
 			this.tableContentStream.fill();
 			this.tableContentStream.closePath();
@@ -813,16 +815,6 @@ public abstract class Table<T extends PDPage> {
 			// Reset NonStroking Color to default value
 			this.tableContentStream.setNonStrokingColor(Color.BLACK);
 		}
-	}
-
-	private float getWidth(Cell<T> cell, Iterator<Cell<T>> cellIterator) {
-		float width;
-		if (cellIterator.hasNext()) {
-			width = cell.getWidth();
-		} else {
-			width = cell.getExtraWidth();
-		}
-		return width;
 	}
 
 	private void ensureStreamIsOpen() throws IOException {

--- a/src/main/java/be/quodlibet/boxable/TableCell.java
+++ b/src/main/java/be/quodlibet/boxable/TableCell.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import be.quodlibet.boxable.utils.PageContentStreamOptimized;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -40,7 +41,7 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 	// default FreeSans font
 //	private PDFont font = FontUtils.getDefaultfonts().get("font");
 //	private PDFont fontBold = FontUtils.getDefaultfonts().get("fontBold");
-	private PDPageContentStream tableCellContentStream;
+	private PageContentStreamOptimized tableCellContentStream;
 
 	// page margins
 	private final float pageTopMargin;
@@ -88,7 +89,7 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 		try {
 			// please consider the cell's paddings
 			float tableWidth = this.width - getLeftPadding() - getRightPadding();
-			tableCellContentStream = new PDPageContentStream(doc, page, true, true);
+			tableCellContentStream = new PageContentStreamOptimized(new PDPageContentStream(doc, page, true, true));
 			// check if there is some additional text outside inner table
 			String[] outerTableText = tableData.split("<table");
 			// don't forget to attach splited tag
@@ -375,7 +376,7 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 		try {
 			// please consider the cell's paddings
 			float tableWidth = this.width - getLeftPadding() - getRightPadding();
-			tableCellContentStream = new PDPageContentStream(doc, page, true, true);
+			tableCellContentStream = new PageContentStreamOptimized(new PDPageContentStream(doc, page, true, true));
 			// check if there is some additional text outside inner table
 			String[] outerTableText = tableData.split("<table");
 			// don't forget to attach splited tag

--- a/src/main/java/be/quodlibet/boxable/TableCell.java
+++ b/src/main/java/be/quodlibet/boxable/TableCell.java
@@ -263,7 +263,6 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 					cursorX += Float.parseFloat(token.getData());
 					break;
 				case ORDERING:
-					tableCellContentStream.beginText();
 					currentFont = paragraph.getFont(boldCounter > 0, italicCounter > 0);
 					tableCellContentStream.setFont(currentFont, getFontSize());
 					if (isTextRotated()) {
@@ -273,19 +272,18 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 							transform.concatenate(AffineTransform.getRotateInstance(Math.PI * 0.5f));
 							transform.concatenate(AffineTransform.getTranslateInstance(-cursorX, -cursorY));
 							tableCellContentStream.setTextMatrix(new Matrix(transform));
-							tableCellContentStream.newLineAtOffset(cursorX, cursorY);
+							tableCellContentStream.newLineAt(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
 						}
 						cursorY += token.getWidth(currentFont) / 1000 * getFontSize();
 					} else {
 						// if it is not calculation then draw it
 						if (!onlyCalculateHeight) {
-							tableCellContentStream.newLineAtOffset(cursorX, cursorY);
+							tableCellContentStream.newLineAt(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
 						}
 						cursorX += token.getWidth(currentFont) / 1000 * getFontSize();
 					}
-					tableCellContentStream.endText();
 					break;
 				case BULLET:
 					float widthOfSpace = currentFont.getSpaceWidth();
@@ -315,22 +313,18 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 					tableCellContentStream.setFont(currentFont, getFontSize());
 					if (isTextRotated()) {
 						if (!onlyCalculateHeight) {
-							tableCellContentStream.beginText();
 							final AffineTransform transform = AffineTransform.getTranslateInstance(cursorX, cursorY);
 							transform.concatenate(AffineTransform.getRotateInstance(Math.PI * 0.5f));
 							transform.concatenate(AffineTransform.getTranslateInstance(-cursorX, -cursorY));
 							tableCellContentStream.setTextMatrix(new Matrix(transform));
-							tableCellContentStream.newLineAtOffset(cursorX, cursorY);
+							tableCellContentStream.newLineAt(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
-							tableCellContentStream.endText();
 						}
 						cursorY += token.getWidth(currentFont) / 1000 * getFontSize();
 					} else {
 						if (!onlyCalculateHeight) {
-							tableCellContentStream.beginText();
-							tableCellContentStream.newLineAtOffset(cursorX, cursorY);
+							tableCellContentStream.newLineAt(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
-							tableCellContentStream.endText();
 						}
 						cursorX += token.getWidth(currentFont) / 1000 * getFontSize();
 					}

--- a/src/main/java/be/quodlibet/boxable/TableCell.java
+++ b/src/main/java/be/quodlibet/boxable/TableCell.java
@@ -1,6 +1,5 @@
 package be.quodlibet.boxable;
 
-import java.awt.geom.AffineTransform;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -11,7 +10,6 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
-import org.apache.pdfbox.util.Matrix;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -204,6 +202,10 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 		int boldCounter = 0;
 		int italicCounter = 0;
 
+		if (!onlyCalculateHeight) {
+			tableCellContentStream.setRotated(isTextRotated());
+		}
+
 		// position at top of current cell descending by font height - font
 		// descent, because we are positioning the base line here
 		float cursorY = yStart - getTopPadding() - FontUtils.getHeight(getFont(), getFontSize())
@@ -268,10 +270,6 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 					if (isTextRotated()) {
 						// if it is not calculation then draw it
 						if (!onlyCalculateHeight) {
-							final AffineTransform transform = AffineTransform.getTranslateInstance(cursorX, cursorY);
-							transform.concatenate(AffineTransform.getRotateInstance(Math.PI * 0.5f));
-							transform.concatenate(AffineTransform.getTranslateInstance(-cursorX, -cursorY));
-							tableCellContentStream.setTextMatrix(new Matrix(transform));
 							tableCellContentStream.newLineAt(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
 						}
@@ -313,10 +311,6 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 					tableCellContentStream.setFont(currentFont, getFontSize());
 					if (isTextRotated()) {
 						if (!onlyCalculateHeight) {
-							final AffineTransform transform = AffineTransform.getTranslateInstance(cursorX, cursorY);
-							transform.concatenate(AffineTransform.getRotateInstance(Math.PI * 0.5f));
-							transform.concatenate(AffineTransform.getTranslateInstance(-cursorX, -cursorY));
-							tableCellContentStream.setTextMatrix(new Matrix(transform));
 							tableCellContentStream.newLineAt(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
 						}

--- a/src/main/java/be/quodlibet/boxable/TableCell.java
+++ b/src/main/java/be/quodlibet/boxable/TableCell.java
@@ -289,34 +289,26 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 					tableCellContentStream.closePath();
 					break;
 				case BULLET:
+					float widthOfSpace = currentFont.getStringWidth(" ");
+					float halfHeight = FontUtils.getHeight(currentFont, getFontSize()) / 2;
 					if (isTextRotated()) {
-						// move cursorX up because bullet needs to be in the
-						// middle of font height
-						cursorX += FontUtils.getHeight(currentFont, getFontSize()) / 2;
 						if (!onlyCalculateHeight) {
-							PDStreamUtils.rect(tableCellContentStream, cursorX, cursorY,
+							PDStreamUtils.rect(tableCellContentStream, cursorX + halfHeight, cursorY,
 									token.getWidth(currentFont) / 1000 * getFontSize(),
-									currentFont.getStringWidth(" ") / 1000 * getFontSize(), getTextColor());
+									widthOfSpace / 1000 * getFontSize(), getTextColor());
 						}
 						// move cursorY for two characters (one for bullet, one
 						// for space after bullet)
-						cursorY += 2 * currentFont.getStringWidth(" ") / 1000 * getFontSize();
-						// return cursorY to his original place
-						cursorX -= FontUtils.getHeight(currentFont, getFontSize()) / 2;
+						cursorY += 2 * widthOfSpace / 1000 * getFontSize();
 					} else {
-						// move cursorY up because bullet needs to be in the
-						// middle of font height
-						cursorY += FontUtils.getHeight(currentFont, getFontSize()) / 2;
 						if (!onlyCalculateHeight) {
-							PDStreamUtils.rect(tableCellContentStream, cursorX, cursorY,
+							PDStreamUtils.rect(tableCellContentStream, cursorX, cursorY + halfHeight,
 									token.getWidth(currentFont) / 1000 * getFontSize(),
-									currentFont.getStringWidth(" ") / 1000 * getFontSize(), getTextColor());
+									widthOfSpace / 1000 * getFontSize(), getTextColor());
 						}
 						// move cursorX for two characters (one for bullet, one
 						// for space after bullet)
-						cursorX += 2 * currentFont.getStringWidth(" ") / 1000 * getFontSize();
-						// return cursorY to his original place
-						cursorY -= FontUtils.getHeight(currentFont, getFontSize()) / 2;
+						cursorX += 2 * widthOfSpace / 1000 * getFontSize();
 					}
 					break;
 				case TEXT:

--- a/src/main/java/be/quodlibet/boxable/TableCell.java
+++ b/src/main/java/be/quodlibet/boxable/TableCell.java
@@ -289,7 +289,7 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 					tableCellContentStream.closePath();
 					break;
 				case BULLET:
-					float widthOfSpace = currentFont.getStringWidth(" ");
+					float widthOfSpace = currentFont.getSpaceWidth();
 					float halfHeight = FontUtils.getHeight(currentFont, getFontSize()) / 2;
 					if (isTextRotated()) {
 						if (!onlyCalculateHeight) {

--- a/src/main/java/be/quodlibet/boxable/TableCell.java
+++ b/src/main/java/be/quodlibet/boxable/TableCell.java
@@ -275,14 +275,14 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 							tableCellContentStream.newLineAtOffset(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
 						}
-						cursorY += currentFont.getStringWidth(token.getData()) / 1000 * getFontSize();
+						cursorY += token.getWidth(currentFont) / 1000 * getFontSize();
 					} else {
 						// if it is not calculation then draw it
 						if (!onlyCalculateHeight) {
 							tableCellContentStream.newLineAtOffset(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
 						}
-						cursorX += currentFont.getStringWidth(token.getData()) / 1000 * getFontSize();
+						cursorX += token.getWidth(currentFont) / 1000 * getFontSize();
 					}
 					tableCellContentStream.endText();
 					tableCellContentStream.closePath();
@@ -294,7 +294,7 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 						cursorX += FontUtils.getHeight(currentFont, getFontSize()) / 2;
 						if (!onlyCalculateHeight) {
 							PDStreamUtils.rect(tableCellContentStream, cursorX, cursorY,
-									currentFont.getStringWidth(token.getData()) / 1000 * getFontSize(),
+									token.getWidth(currentFont) / 1000 * getFontSize(),
 									currentFont.getStringWidth(" ") / 1000 * getFontSize(), getTextColor());
 						}
 						// move cursorY for two characters (one for bullet, one
@@ -308,7 +308,7 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 						cursorY += FontUtils.getHeight(currentFont, getFontSize()) / 2;
 						if (!onlyCalculateHeight) {
 							PDStreamUtils.rect(tableCellContentStream, cursorX, cursorY,
-									currentFont.getStringWidth(token.getData()) / 1000 * getFontSize(),
+									token.getWidth(currentFont) / 1000 * getFontSize(),
 									currentFont.getStringWidth(" ") / 1000 * getFontSize(), getTextColor());
 						}
 						// move cursorX for two characters (one for bullet, one
@@ -333,7 +333,7 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 							tableCellContentStream.endText();
 							tableCellContentStream.closePath();
 						}
-						cursorY += currentFont.getStringWidth(token.getData()) / 1000 * getFontSize();
+						cursorY += token.getWidth(currentFont) / 1000 * getFontSize();
 					} else {
 						if (!onlyCalculateHeight) {
 							tableCellContentStream.beginText();
@@ -342,7 +342,7 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 							tableCellContentStream.endText();
 							tableCellContentStream.closePath();
 						}
-						cursorX += currentFont.getStringWidth(token.getData()) / 1000 * getFontSize();
+						cursorX += token.getWidth(currentFont) / 1000 * getFontSize();
 					}
 					break;
 				}

--- a/src/main/java/be/quodlibet/boxable/TableCell.java
+++ b/src/main/java/be/quodlibet/boxable/TableCell.java
@@ -286,7 +286,6 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 						cursorX += token.getWidth(currentFont) / 1000 * getFontSize();
 					}
 					tableCellContentStream.endText();
-					tableCellContentStream.closePath();
 					break;
 				case BULLET:
 					float widthOfSpace = currentFont.getSpaceWidth();
@@ -324,7 +323,6 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 							tableCellContentStream.newLineAtOffset(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
 							tableCellContentStream.endText();
-							tableCellContentStream.closePath();
 						}
 						cursorY += token.getWidth(currentFont) / 1000 * getFontSize();
 					} else {
@@ -333,7 +331,6 @@ public class TableCell<T extends PDPage> extends Cell<T> {
 							tableCellContentStream.newLineAtOffset(cursorX, cursorY);
 							tableCellContentStream.showText(token.getData());
 							tableCellContentStream.endText();
-							tableCellContentStream.closePath();
 						}
 						cursorX += token.getWidth(currentFont) / 1000 * getFontSize();
 					}

--- a/src/main/java/be/quodlibet/boxable/image/Image.java
+++ b/src/main/java/be/quodlibet/boxable/image/Image.java
@@ -3,6 +3,7 @@ package be.quodlibet.boxable.image;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 
+import be.quodlibet.boxable.utils.PageContentStreamOptimized;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
@@ -63,7 +64,7 @@ public class Image {
 	 *            Y coordinate for image drawing
 	 * @throws IOException if loading image fails
 	 */
-	public void draw(final PDDocument doc, final PDPageContentStream stream, float x, float y) throws IOException {
+	public void draw(final PDDocument doc, final PageContentStreamOptimized stream, float x, float y) throws IOException {
 		PDImageXObject imageXObject = LosslessFactory.createFromImage(doc, image);
 		stream.drawImage(imageXObject, x, y - height, width, height);
 	}

--- a/src/main/java/be/quodlibet/boxable/text/PipelineLayer.java
+++ b/src/main/java/be/quodlibet/boxable/text/PipelineLayer.java
@@ -15,7 +15,19 @@ import org.apache.pdfbox.pdmodel.font.PDFont;
 
 public class PipelineLayer {
 
-	private final Pattern whitespace = Pattern.compile("(?:\r\n|\n\r|[ \t\n\r\\f])+\\z");
+	private static String rtrim(String s) {
+		int len = s.length();
+		while ((len > 0) && (s.charAt(len - 1) <= ' ')) {
+			len--;
+		}
+		if (len == s.length()) {
+			return s;
+		}
+		if (len == 0) {
+			return "";
+		}
+		return s.substring(0, len);
+	}
 
 	private final StringBuilder text = new StringBuilder();
 
@@ -61,7 +73,7 @@ public class PipelineLayer {
 			text.append(lastTextToken);
 			width += widthLastToken;
 			lastTextToken = token.getData();
-			trimmedLastTextToken = whitespace.matcher(lastTextToken).replaceAll("");
+			trimmedLastTextToken = rtrim(lastTextToken);
 			widthLastToken = (font.getStringWidth(lastTextToken) / 1000f * fontSize);
 			widthTrimmedLastToken = (font.getStringWidth(trimmedLastTextToken) / 1000f * fontSize);
 			widthCurrentText = (font.getStringWidth(text.toString()) / 1000f * fontSize);

--- a/src/main/java/be/quodlibet/boxable/text/PipelineLayer.java
+++ b/src/main/java/be/quodlibet/boxable/text/PipelineLayer.java
@@ -75,8 +75,15 @@ public class PipelineLayer {
 			lastTextToken = token.getData();
 			trimmedLastTextToken = rtrim(lastTextToken);
 			widthLastToken = (font.getStringWidth(lastTextToken) / 1000f * fontSize);
-			widthTrimmedLastToken = (font.getStringWidth(trimmedLastTextToken) / 1000f * fontSize);
-			widthCurrentText = (font.getStringWidth(text.toString()) / 1000f * fontSize);
+
+			if (trimmedLastTextToken.length() == lastTextToken.length()) {
+				widthTrimmedLastToken = widthLastToken;
+			} else {
+				widthTrimmedLastToken = (font.getStringWidth(trimmedLastTextToken) / 1000f * fontSize);
+			}
+
+			widthCurrentText = text.length() == 0 ? 0 :
+					(font.getStringWidth(text.toString()) / 1000f * fontSize);
 		}
 
 		push(token);

--- a/src/main/java/be/quodlibet/boxable/text/PipelineLayer.java
+++ b/src/main/java/be/quodlibet/boxable/text/PipelineLayer.java
@@ -60,13 +60,13 @@ public class PipelineLayer {
 		if (token.getType().equals(TokenType.BULLET)) {
 			// just appending one space because our bullet width will be wide as one character of current font
 			text.append(token.getData());
-			width += (font.getStringWidth(token.getData()) / 1000f * fontSize);
+			width += (token.getWidth(font) / 1000f * fontSize);
 		}
 
 		if (token.getType().equals(TokenType.ORDERING)) {
 			// just appending one space because our bullet width will be wide as one character of current font
 			text.append(token.getData());
-			width += (font.getStringWidth(token.getData()) / 1000f * fontSize);
+			width += (token.getWidth(font) / 1000f * fontSize);
 		}
 
 		if (token.getType().equals(TokenType.TEXT)) {
@@ -74,7 +74,7 @@ public class PipelineLayer {
 			width += widthLastToken;
 			lastTextToken = token.getData();
 			trimmedLastTextToken = rtrim(lastTextToken);
-			widthLastToken = (font.getStringWidth(lastTextToken) / 1000f * fontSize);
+			widthLastToken = token.getWidth(font) / 1000f * fontSize;
 
 			if (trimmedLastTextToken.length() == lastTextToken.length()) {
 				widthTrimmedLastToken = widthLastToken;

--- a/src/main/java/be/quodlibet/boxable/text/Token.java
+++ b/src/main/java/be/quodlibet/boxable/text/Token.java
@@ -1,10 +1,17 @@
 package be.quodlibet.boxable.text;
 
+import org.apache.pdfbox.pdmodel.font.PDFont;
+
+import java.io.IOException;
+
 public class Token {
 
 	private final TokenType type;
 	
 	private final String data;
+
+	private PDFont cachedWidthFont;
+	private float cachedWidth;
 
 	public Token(TokenType type, String data) {
 		this.type = type;
@@ -17,6 +24,16 @@ public class Token {
 	
 	public TokenType getType() {
 		return type;
+	}
+
+	public float getWidth(PDFont font) throws IOException {
+		if (font == cachedWidthFont) {
+			return cachedWidth;
+		}
+		cachedWidth = font.getStringWidth(data);
+		// must come after getStringWidth(), in case it throws
+		cachedWidthFont = font;
+		return cachedWidth;
 	}
 	
 	@Override

--- a/src/main/java/be/quodlibet/boxable/text/Token.java
+++ b/src/main/java/be/quodlibet/boxable/text/Token.java
@@ -3,15 +3,15 @@ package be.quodlibet.boxable.text;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 
 import java.io.IOException;
+import java.util.Objects;
 
+// Token itself is thread safe, so you can reuse shared instances;
+// however, subclasses may have additional methods which are not thread safe.
 public class Token {
 
 	private final TokenType type;
 	
 	private final String data;
-
-	private PDFont cachedWidthFont;
-	private float cachedWidth;
 
 	public Token(TokenType type, String data) {
 		this.type = type;
@@ -27,17 +27,51 @@ public class Token {
 	}
 
 	public float getWidth(PDFont font) throws IOException {
-		if (font == cachedWidthFont) {
-			return cachedWidth;
-		}
-		cachedWidth = font.getStringWidth(data);
-		// must come after getStringWidth(), in case it throws
-		cachedWidthFont = font;
-		return cachedWidth;
+		return font.getStringWidth(getData());
 	}
-	
+
 	@Override
 	public String toString() {
 		return getClass().getSimpleName() + "[" + type + "/" + data + "]";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Token token = (Token) o;
+		return getType() == token.getType() &&
+				Objects.equals(getData(), token.getData());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getType(), getData());
+	}
+
+	// Returns non-thread safe instance optimized for renderable text
+	public static Token text(TokenType type, String data) {
+		return new TextToken(type, data);
+	}
+}
+
+// Non-thread safe subclass with caching to optimize tokens containing renderable text
+class TextToken extends Token {
+	private PDFont cachedWidthFont;
+	private float cachedWidth;
+
+	TextToken(TokenType type, String data) {
+		super(type, data);
+	}
+
+	@Override
+	public float getWidth(PDFont font) throws IOException {
+		if (font == cachedWidthFont) {
+			return cachedWidth;
+		}
+		cachedWidth = super.getWidth(font);
+		// must come after super call, in case it throws
+		cachedWidthFont = font;
+		return cachedWidth;
 	}
 }

--- a/src/main/java/be/quodlibet/boxable/text/Tokenizer.java
+++ b/src/main/java/be/quodlibet/boxable/text/Tokenizer.java
@@ -7,6 +7,21 @@ import java.util.Stack;
 
 public final class Tokenizer {
 
+	private static final Token OPEN_TAG_I = new Token(TokenType.OPEN_TAG, "i");
+	private static final Token OPEN_TAG_B = new Token(TokenType.OPEN_TAG, "b");
+	private static final Token OPEN_TAG_OL = new Token(TokenType.OPEN_TAG, "ol");
+	private static final Token OPEN_TAG_UL = new Token(TokenType.OPEN_TAG, "ul");
+	private static final Token CLOSE_TAG_I = new Token(TokenType.CLOSE_TAG, "i");
+	private static final Token CLOSE_TAG_B = new Token(TokenType.CLOSE_TAG, "b");
+	private static final Token CLOSE_TAG_OL = new Token(TokenType.CLOSE_TAG, "ol");
+	private static final Token CLOSE_TAG_UL = new Token(TokenType.CLOSE_TAG, "ul");
+	private static final Token CLOSE_TAG_P = new Token(TokenType.CLOSE_TAG, "p");
+	private static final Token CLOSE_TAG_LI = new Token(TokenType.CLOSE_TAG, "li");
+	private static final Token POSSIBLE_WRAP_POINT = new Token(TokenType.POSSIBLE_WRAP_POINT, "");
+	private static final Token WRAP_POINT_P = new Token(TokenType.WRAP_POINT, "p");
+	private static final Token WRAP_POINT_LI = new Token(TokenType.WRAP_POINT, "li");
+	private static final Token WRAP_POINT_BR = new Token(TokenType.WRAP_POINT, "br");
+
 	private Tokenizer() {
 	}
 
@@ -63,10 +78,10 @@ public final class Tokenizer {
 			while (textIndex < text.length()) {
 				if (textIndex == currentWrapPoint) {
 					if (sb.length() > 0) {
-						tokens.add(new Token(TokenType.TEXT, sb.toString()));
+						tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 						sb.delete(0, sb.length());
 					}
-					tokens.add(new Token(TokenType.POSSIBLE_WRAP_POINT, "" + textIndex));
+					tokens.add(POSSIBLE_WRAP_POINT);
 					currentWrapPoint = possibleWrapPoints.pop();
 				}
 				final char c = text.charAt(textIndex);
@@ -79,21 +94,21 @@ public final class Tokenizer {
 						if ('i' == lookahead1 && '>' == lookahead2) {
 							// <i>
 							if (sb.length() > 0) {
-								tokens.add(new Token(TokenType.TEXT, sb.toString()));
+								tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 								// clean string builder
 								sb.delete(0, sb.length());
 							}
-							tokens.add(new Token(TokenType.OPEN_TAG, "i"));
+							tokens.add(OPEN_TAG_I);
 							textIndex += 2;
 							consumed = true;
 						} else if ('b' == lookahead1 && '>' == lookahead2) {
 							// <b>
 							if (sb.length() > 0) {
-								tokens.add(new Token(TokenType.TEXT, sb.toString()));
+								tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 								// clean string builder
 								sb.delete(0, sb.length());
 							}
-							tokens.add(new Token(TokenType.OPEN_TAG, "b"));
+							tokens.add(OPEN_TAG_B);
 							textIndex += 2;
 							consumed = true;
 						} else if ('b' == lookahead1 && 'r' == lookahead2) {
@@ -102,11 +117,11 @@ public final class Tokenizer {
 								final char lookahead3 = text.charAt(textIndex + 3);
 								if (lookahead3 == '>') {
 									if (sb.length() > 0) {
-										tokens.add(new Token(TokenType.TEXT, sb.toString()));
+										tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 										// clean string builder
 										sb.delete(0, sb.length());
 									}
-									tokens.add(new Token(TokenType.WRAP_POINT, "br"));
+									tokens.add(WRAP_POINT_BR);
 									// normal notation <br>
 									textIndex += 3;
 									consumed = true;
@@ -115,11 +130,11 @@ public final class Tokenizer {
 									final char lookahead4 = text.charAt(textIndex + 4);
 									if (lookahead3 == '/' && lookahead4 == '>') {
 										if (sb.length() > 0) {
-											tokens.add(new Token(TokenType.TEXT, sb.toString()));
+											tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 											// clean string builder
 											sb.delete(0, sb.length());
 										}
-										tokens.add(new Token(TokenType.WRAP_POINT, "br"));
+										tokens.add(WRAP_POINT_BR);
 										// normal notation <br/>
 										textIndex += 4;
 										consumed = true;
@@ -127,11 +142,11 @@ public final class Tokenizer {
 										final char lookahead5 = text.charAt(textIndex + 5);
 										if (lookahead3 == ' ' && lookahead4 == '/' && lookahead5 == '>') {
 											if (sb.length() > 0) {
-												tokens.add(new Token(TokenType.TEXT, sb.toString()));
+												tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 												// clean string builder
 												sb.delete(0, sb.length());
 											}
-											tokens.add(new Token(TokenType.WRAP_POINT, "br"));
+											tokens.add(WRAP_POINT_BR);
 											// in case it is notation <br />
 											textIndex += 5;
 											consumed = true;
@@ -142,11 +157,11 @@ public final class Tokenizer {
 						} else if ('p' == lookahead1 && '>' == lookahead2) {
 							// <p>
 							if (sb.length() > 0) {
-								tokens.add(new Token(TokenType.TEXT, sb.toString()));
+								tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 								// clean string builder
 								sb.delete(0, sb.length());
 							}
-							tokens.add(new Token(TokenType.WRAP_POINT, "p"));
+							tokens.add(WRAP_POINT_P);
 							textIndex += 2;
 							consumed = true;
 						} else if ('o' == lookahead1 && 'l' == lookahead2) {
@@ -155,11 +170,11 @@ public final class Tokenizer {
 								final char lookahead3 = text.charAt(textIndex + 3);
 								if (lookahead3 == '>') {
 									if (sb.length() > 0) {
-										tokens.add(new Token(TokenType.TEXT, sb.toString()));
+										tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 										// clean string builder
 										sb.delete(0, sb.length());
 									}
-									tokens.add(new Token(TokenType.OPEN_TAG, "ol"));
+									tokens.add(OPEN_TAG_OL);
 									textIndex += 3;
 									consumed = true;
 								}
@@ -170,11 +185,11 @@ public final class Tokenizer {
 								final char lookahead3 = text.charAt(textIndex + 3);
 								if (lookahead3 == '>') {
 									if (sb.length() > 0) {
-										tokens.add(new Token(TokenType.TEXT, sb.toString()));
+										tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 										// clean string builder
 										sb.delete(0, sb.length());
 									}
-									tokens.add(new Token(TokenType.OPEN_TAG, "ul"));
+									tokens.add(OPEN_TAG_UL);
 									textIndex += 3;
 									consumed = true;
 								}
@@ -185,11 +200,11 @@ public final class Tokenizer {
 								final char lookahead3 = text.charAt(textIndex + 3);
 								if (lookahead3 == '>') {
 									if (sb.length() > 0) {
-										tokens.add(new Token(TokenType.TEXT, sb.toString()));
+										tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 										// clean string builder
 										sb.delete(0, sb.length());
 									}
-									tokens.add(new Token(TokenType.WRAP_POINT, "li"));
+									tokens.add(WRAP_POINT_LI);
 									textIndex += 3;
 									consumed = true;
 								}
@@ -202,28 +217,28 @@ public final class Tokenizer {
 									if ('i' == lookahead2) {
 										// </i>
 										if (sb.length() > 0) {
-											tokens.add(new Token(TokenType.TEXT, sb.toString()));
+											tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 											sb.delete(0, sb.length());
 										}
-										tokens.add(new Token(TokenType.CLOSE_TAG, "i"));
+										tokens.add(CLOSE_TAG_I);
 										textIndex += 3;
 										consumed = true;
 									} else if ('b' == lookahead2) {
 										// </b>
 										if (sb.length() > 0) {
-											tokens.add(new Token(TokenType.TEXT, sb.toString()));
+											tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 											sb.delete(0, sb.length());
 										}
-										tokens.add(new Token(TokenType.CLOSE_TAG, "b"));
+										tokens.add(CLOSE_TAG_B);
 										textIndex += 3;
 										consumed = true;
 									} else if ('p' == lookahead2) {
 										//</p>
 										if (sb.length() > 0) {
-											tokens.add(new Token(TokenType.TEXT, sb.toString()));
+											tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 											sb.delete(0, sb.length());
 										}
-										tokens.add(new Token(TokenType.CLOSE_TAG, "p"));
+										tokens.add(CLOSE_TAG_P);
 										textIndex += 3;
 										consumed = true;
 									}
@@ -237,19 +252,19 @@ public final class Tokenizer {
 									if ('o' == lookahead2 && '>' == lookahead4) {
 										// </ol>
 										if (sb.length() > 0) {
-											tokens.add(new Token(TokenType.TEXT, sb.toString()));
+											tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 											sb.delete(0, sb.length());
 										}
-										tokens.add(new Token(TokenType.CLOSE_TAG, "ol"));
+										tokens.add(CLOSE_TAG_OL);
 										textIndex += 4;
 										consumed = true;
 									} else if ('u' == lookahead2 && '>' == lookahead4) {
 										// </ul>
 										if (sb.length() > 0) {
-											tokens.add(new Token(TokenType.TEXT, sb.toString()));
+											tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 											sb.delete(0, sb.length());
 										}
-										tokens.add(new Token(TokenType.CLOSE_TAG, "ul"));
+										tokens.add(CLOSE_TAG_UL);
 										textIndex += 4;
 										consumed = true;
 									}
@@ -257,10 +272,10 @@ public final class Tokenizer {
 									// </li>
 									if ('>' == lookahead4) {
 										if (sb.length() > 0) {
-											tokens.add(new Token(TokenType.TEXT, sb.toString()));
+											tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 											sb.delete(0, sb.length());
 										}
-										tokens.add(new Token(TokenType.CLOSE_TAG, "li"));
+										tokens.add(CLOSE_TAG_LI);
 										textIndex += 4;
 										consumed = true;
 									}
@@ -281,10 +296,10 @@ public final class Tokenizer {
 			}
 
 			if (sb.length() > 0) {
-				tokens.add(new Token(TokenType.TEXT, sb.toString()));
+				tokens.add(Token.text(TokenType.TEXT, sb.toString()));
 				sb.delete(0, sb.length());
 			}
-			tokens.add(new Token(TokenType.POSSIBLE_WRAP_POINT, "" + textIndex));
+			tokens.add(POSSIBLE_WRAP_POINT);
 
 			return tokens;
 		} else

--- a/src/main/java/be/quodlibet/boxable/text/Tokenizer.java
+++ b/src/main/java/be/quodlibet/boxable/text/Tokenizer.java
@@ -10,19 +10,53 @@ public final class Tokenizer {
 	private Tokenizer() {
 	}
 
+	private static boolean isWrapPointChar(char ch) {
+		return
+				ch == ' '  ||
+				ch == ','  ||
+				ch == '.'  ||
+				ch == '-'  ||
+				ch == '@'  ||
+				ch == ':'  ||
+				ch == ';'  ||
+				ch == '\n' ||
+				ch == '\t' ||
+				ch == '\r' ||
+				ch == '\f' ||
+				ch == '\u000B';
+	}
+
+	private static Stack<Integer> findWrapPoints(String text) {
+		Stack<Integer> result = new Stack<>();
+		result.push(text.length());
+		for (int i = text.length() - 2; i >= 0; i--) {
+			if (isWrapPointChar(text.charAt(i))) {
+				result.push(i + 1);
+			}
+		}
+		return result;
+	}
+
+	private static Stack<Integer> findWrapPointsWithFunction(String text, WrappingFunction wrappingFunction) {
+		final String[] split = wrappingFunction.getLines(text);
+		int textIndex = text.length();
+		final Stack<Integer> possibleWrapPoints = new Stack<>();
+		possibleWrapPoints.push(textIndex);
+		for (int i = split.length - 1; i > 0; i--) {
+			final int splitLength = split[i].length();
+			possibleWrapPoints.push(textIndex - splitLength);
+			textIndex -= splitLength;
+		}
+		return possibleWrapPoints;
+	}
+
 	public static List<Token> tokenize(final String text, final WrappingFunction wrappingFunction) {
 		final List<Token> tokens = new ArrayList<>();
 		if (text != null) {
-			final String[] split = wrappingFunction.getLines(text);
-			int textIndex = text.length();
-			final Stack<Integer> possibleWrapPoints = new Stack<>();
-			possibleWrapPoints.push(textIndex);
-			for (int i = split.length - 1; i > 0; i--) {
-				final int splitLength = split[i].length();
-				possibleWrapPoints.push(textIndex - splitLength);
-				textIndex -= splitLength;
-			}
-			textIndex = 0;
+			final Stack<Integer> possibleWrapPoints = wrappingFunction == null
+					? findWrapPoints(text)
+					: findWrapPointsWithFunction(text, wrappingFunction);
+			int textIndex = 0;
 			final StringBuilder sb = new StringBuilder();
 			// taking first wrap point
 			Integer currentWrapPoint = possibleWrapPoints.pop();

--- a/src/main/java/be/quodlibet/boxable/utils/PDStreamUtils.java
+++ b/src/main/java/be/quodlibet/boxable/utils/PDStreamUtils.java
@@ -83,7 +83,6 @@ public final class PDStreamUtils {
 			// negative height because we want to draw down (not up!)
 			stream.addRect(x, y, width, -height);
 			stream.fill();
-			stream.closePath();
 
 			// Reset NonStroking Color to default value
 			stream.setNonStrokingColor(Color.BLACK);

--- a/src/main/java/be/quodlibet/boxable/utils/PDStreamUtils.java
+++ b/src/main/java/be/quodlibet/boxable/utils/PDStreamUtils.java
@@ -46,13 +46,11 @@ public final class PDStreamUtils {
 	public static void write(final PageContentStreamOptimized stream, final String text, final PDFont font,
 			final float fontSize, final float x, final float y, final Color color) {
 		try {
-			stream.beginText();
 			stream.setFont(font, fontSize);
 			// we want to position our text on his baseline
-			stream.newLineAtOffset(x, y - FontUtils.getDescent(font, fontSize) - FontUtils.getHeight(font, fontSize));
+			stream.newLineAt(x, y - FontUtils.getDescent(font, fontSize) - FontUtils.getHeight(font, fontSize));
 			stream.setNonStrokingColor(color);
 			stream.showText(text);
-			stream.endText();
 		} catch (final IOException e) {
 			throw new IllegalStateException("Unable to write text", e);
 		}

--- a/src/main/java/be/quodlibet/boxable/utils/PDStreamUtils.java
+++ b/src/main/java/be/quodlibet/boxable/utils/PDStreamUtils.java
@@ -81,9 +81,6 @@ public final class PDStreamUtils {
 			// negative height because we want to draw down (not up!)
 			stream.addRect(x, y, width, -height);
 			stream.fill();
-
-			// Reset NonStroking Color to default value
-			stream.setNonStrokingColor(Color.BLACK);
 		} catch (final IOException e) {
 			throw new IllegalStateException("Unable to draw rectangle", e);
 		}
@@ -130,7 +127,6 @@ public final class PDStreamUtils {
 	 * @throws IOException If the content stream could not be written or the line color cannot be retrieved.
 	 */
 	public static void setLineStyles(final PageContentStreamOptimized stream, final LineStyle line) throws IOException {
-		stream.setNonStrokingColor(line.getColor());
 		stream.setStrokingColor(line.getColor());
 		stream.setLineWidth(line.getWidth());
 		stream.setLineCapStyle(0);

--- a/src/main/java/be/quodlibet/boxable/utils/PDStreamUtils.java
+++ b/src/main/java/be/quodlibet/boxable/utils/PDStreamUtils.java
@@ -43,7 +43,7 @@ public final class PDStreamUtils {
 	 * @param color
 	 *            Color of the text
 	 */
-	public static void write(final PDPageContentStream stream, final String text, final PDFont font,
+	public static void write(final PageContentStreamOptimized stream, final String text, final PDFont font,
 			final float fontSize, final float x, final float y, final Color color) {
 		try {
 			stream.beginText();
@@ -76,7 +76,7 @@ public final class PDStreamUtils {
 	 * @param color
 	 *            Color of the text
 	 */
-	public static void rect(final PDPageContentStream stream, final float x, final float y, final float width,
+	public static void rect(final PageContentStreamOptimized stream, final float x, final float y, final float width,
 			final float height, final Color color) {
 		try {
 			stream.setNonStrokingColor(color);
@@ -109,7 +109,7 @@ public final class PDStreamUtils {
 	 * @param fontSize
 	 *            Font size
 	 */
-	public static void rectFontMetrics(final PDPageContentStream stream, final float x, final float y,
+	public static void rectFontMetrics(final PageContentStreamOptimized stream, final float x, final float y,
 			final PDFont font, final float fontSize) {
 		// height
 		PDStreamUtils.rect(stream, x, y, 3, FontUtils.getHeight(font, fontSize), Color.BLUE);
@@ -132,7 +132,7 @@ public final class PDStreamUtils {
 	 *            The {@link LineStyle} that would be applied
 	 * @throws IOException If the content stream could not be written or the line color cannot be retrieved.
 	 */
-	public static void setLineStyles(final PDPageContentStream stream, final LineStyle line) throws IOException {
+	public static void setLineStyles(final PageContentStreamOptimized stream, final LineStyle line) throws IOException {
 		stream.setNonStrokingColor(line.getColor());
 		stream.setStrokingColor(line.getColor());
 		stream.setLineWidth(line.getWidth());

--- a/src/main/java/be/quodlibet/boxable/utils/PageContentStreamOptimized.java
+++ b/src/main/java/be/quodlibet/boxable/utils/PageContentStreamOptimized.java
@@ -36,7 +36,7 @@ public class PageContentStreamOptimized {
         this.rotated = rotated;
     }
 
-    private void beginText() throws IOException {
+    public void beginText() throws IOException {
         if (!textMode) {
             pageContentStream.beginText();
             if (rotated) {
@@ -48,7 +48,7 @@ public class PageContentStreamOptimized {
         }
     }
 
-    private void endText() throws IOException {
+    public void endText() throws IOException {
         if (textMode) {
             pageContentStream.endText();
             textMode = false;
@@ -166,6 +166,7 @@ public class PageContentStreamOptimized {
     }
 
     public void close() throws IOException {
+        endText();
         pageContentStream.close();
     }
 }

--- a/src/main/java/be/quodlibet/boxable/utils/PageContentStreamOptimized.java
+++ b/src/main/java/be/quodlibet/boxable/utils/PageContentStreamOptimized.java
@@ -86,32 +86,8 @@ public class PageContentStreamOptimized {
         pageContentStream.stroke();
     }
 
-    public void closeAndStroke() throws IOException {
-        pageContentStream.closeAndStroke();
-    }
-
     public void fill() throws IOException {
         pageContentStream.fill();
-    }
-
-    public void fillAndStroke() throws IOException {
-        pageContentStream.fillAndStroke();
-    }
-
-    public void fillAndStrokeEvenOdd() throws IOException {
-        pageContentStream.fillAndStrokeEvenOdd();
-    }
-
-    public void closeAndFillAndStroke() throws IOException {
-        pageContentStream.closeAndFillAndStroke();
-    }
-
-    public void closeAndFillAndStrokeEvenOdd() throws IOException {
-        pageContentStream.closeAndFillAndStrokeEvenOdd();
-    }
-
-    public void closePath() throws IOException {
-        pageContentStream.closePath();
     }
 
     private float currentLineWidth = -1;

--- a/src/main/java/be/quodlibet/boxable/utils/PageContentStreamOptimized.java
+++ b/src/main/java/be/quodlibet/boxable/utils/PageContentStreamOptimized.java
@@ -1,0 +1,180 @@
+package be.quodlibet.boxable.utils;
+
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.util.Matrix;
+
+import java.awt.Color;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class PageContentStreamOptimized {
+    final PDPageContentStream pageContentStream;
+
+    public PageContentStreamOptimized(PDPageContentStream pageContentStream) {
+        this.pageContentStream = pageContentStream;
+    }
+
+    public void beginText() throws IOException {
+        pageContentStream.beginText();
+    }
+
+    public void endText() throws IOException {
+        pageContentStream.endText();
+    }
+
+    private PDFont currentFont;
+    private float currentFontSize;
+
+    public void setFont(PDFont font, float fontSize) throws IOException {
+        if (font != currentFont || fontSize != currentFontSize) {
+            pageContentStream.setFont(font, fontSize);
+            currentFont = font;
+            currentFontSize = fontSize;
+        }
+    }
+
+    public void showText(String text) throws IOException {
+        pageContentStream.showText(text);
+    }
+
+    public void newLineAtOffset(float tx, float ty) throws IOException {
+        pageContentStream.newLineAtOffset(tx, ty);
+    }
+
+    public void setTextMatrix(Matrix matrix) throws IOException {
+        pageContentStream.setTextMatrix(matrix);
+    }
+
+    public void drawImage(PDImageXObject image, float x, float y, float width, float height) throws IOException {
+        pageContentStream.drawImage(image, x, y, width, height);
+    }
+
+    private Color currentStrokingColor;
+
+    public void setStrokingColor(Color color) throws IOException {
+        if (color != currentStrokingColor) {
+            pageContentStream.setStrokingColor(color);
+            currentStrokingColor = color;
+        }
+    }
+
+    private Color currentNonStrokingColor;
+
+    public void setNonStrokingColor(Color color) throws IOException {
+        if (color != currentNonStrokingColor) {
+            pageContentStream.setNonStrokingColor(color);
+            currentNonStrokingColor = color;
+        }
+    }
+
+    public void addRect(float x, float y, float width, float height) throws IOException {
+        pageContentStream.addRect(x, y, width, height);
+    }
+
+    public void moveTo(float x, float y) throws IOException {
+        pageContentStream.moveTo(x, y);
+    }
+
+    public void lineTo(float x, float y) throws IOException {
+        pageContentStream.lineTo(x, y);
+    }
+
+    public void stroke() throws IOException {
+        pageContentStream.stroke();
+    }
+
+    public void closeAndStroke() throws IOException {
+        pageContentStream.closeAndStroke();
+    }
+
+    public void fill() throws IOException {
+        pageContentStream.fill();
+    }
+
+    public void fillAndStroke() throws IOException {
+        pageContentStream.fillAndStroke();
+    }
+
+    public void fillAndStrokeEvenOdd() throws IOException {
+        pageContentStream.fillAndStrokeEvenOdd();
+    }
+
+    public void closeAndFillAndStroke() throws IOException {
+        pageContentStream.closeAndFillAndStroke();
+    }
+
+    public void closeAndFillAndStrokeEvenOdd() throws IOException {
+        pageContentStream.closeAndFillAndStrokeEvenOdd();
+    }
+
+    public void closePath() throws IOException {
+        pageContentStream.closePath();
+    }
+
+    private float currentLineWidth = -1;
+
+    public void setLineWidth(float lineWidth) throws IOException {
+        if (lineWidth != currentLineWidth) {
+            pageContentStream.setLineWidth(lineWidth);
+            currentLineWidth = lineWidth;
+        }
+    }
+
+    private int currentLineCapStyle = -1;
+
+    public void setLineCapStyle(int lineCapStyle) throws IOException {
+        if (lineCapStyle != currentLineCapStyle) {
+            pageContentStream.setLineCapStyle(lineCapStyle);
+            currentLineCapStyle = lineCapStyle;
+        }
+    }
+
+    private float[] currentLineDashPattern;
+    private float currentLineDashPhase;
+
+    public void setLineDashPattern(float[] pattern, float phase) throws IOException {
+        if ((pattern != currentLineDashPattern &&
+            !Arrays.equals(pattern, currentLineDashPattern)) || phase != currentLineDashPhase) {
+            pageContentStream.setLineDashPattern(pattern, phase);
+            currentLineDashPattern = pattern;
+            currentLineDashPhase = phase;
+        }
+    }
+
+    @Deprecated
+    public void appendRawCommands(String commands) throws IOException {
+        pageContentStream.appendRawCommands(commands);
+    }
+
+    @Deprecated
+    public void appendRawCommands(byte[] commands) throws IOException {
+        pageContentStream.appendRawCommands(commands);
+    }
+
+    @Deprecated
+    public void appendRawCommands(int data) throws IOException {
+        pageContentStream.appendRawCommands(data);
+    }
+
+    @Deprecated
+    public void appendRawCommands(double data) throws IOException {
+        pageContentStream.appendRawCommands(data);
+    }
+
+    @Deprecated
+    public void appendRawCommands(float data) throws IOException {
+        pageContentStream.appendRawCommands(data);
+    }
+
+    @Deprecated
+    public void appendCOSName(COSName name) throws IOException {
+        pageContentStream.appendCOSName(name);
+    }
+
+    public void close() throws IOException {
+        pageContentStream.close();
+    }
+}

--- a/src/test/java/be/quodlibet/boxable/TableTest.java
+++ b/src/test/java/be/quodlibet/boxable/TableTest.java
@@ -11,6 +11,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
+import be.quodlibet.boxable.utils.PageContentStreamOptimized;
 import org.apache.fontbox.util.BoundingBox;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -1134,7 +1135,7 @@ public class TableTest {
 		float bottomMargin = 70;
 
 		// draw page title
-		PDPageContentStream cos = new PDPageContentStream(doc, page);
+		PageContentStreamOptimized cos = new PageContentStreamOptimized(new PDPageContentStream(doc, page));
 		PDStreamUtils.write(cos, "Welcome to your first borderless table", PDType1Font.HELVETICA_BOLD, 14, 15, yStart,
 				Color.BLACK);
 		cos.close();

--- a/src/test/java/be/quodlibet/boxable/text/TokenizerTest.java
+++ b/src/test/java/be/quodlibet/boxable/text/TokenizerTest.java
@@ -1,6 +1,6 @@
 package be.quodlibet.boxable.text;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -9,32 +9,22 @@ import org.junit.Test;
 
 public class TokenizerTest {
 	
-	private WrappingFunction wrappingFunction = new WrappingFunction() {
-		@Override
-		public String[] getLines(String t) {
-			return t.split("(?<=\\s|-|@|,|\\.|:|;)");
-		}
-	};
+	private WrappingFunction wrappingFunction = null;
 
 	@Test
 	public void testWrapPoints() throws Exception {
 		final String text = "1 123 123456 12";
-		final String[] lines = wrappingFunction.getLines(text);
-		final List<Integer> expected = new ArrayList<>();
-		int pos = 0;
-		for (final String line : lines) {
-			pos += line.length();
-			expected.add(pos);
-		}
-		int index = 0;
 		final List<Token> tokens = Tokenizer.tokenize(text, wrappingFunction);
-		for (final Token token : tokens) {
-			if (TokenType.POSSIBLE_WRAP_POINT.equals(token.getType())) {
-				Assert.assertEquals("Wrap point " + index + " is wrong", "" + expected.get(index), token.getData());
-				index++;
-			}
-		}
-		Assert.assertEquals("Not all possible wrap points were defined", index, expected.size());
+		Assert.assertEquals(Arrays.asList(
+				Token.text(TokenType.TEXT, "1 "),
+				new Token(TokenType.POSSIBLE_WRAP_POINT, ""),
+				Token.text(TokenType.TEXT, "123 "),
+				new Token(TokenType.POSSIBLE_WRAP_POINT, ""),
+				Token.text(TokenType.TEXT, "123456 "),
+				new Token(TokenType.POSSIBLE_WRAP_POINT, ""),
+				Token.text(TokenType.TEXT, "12"),
+				new Token(TokenType.POSSIBLE_WRAP_POINT, "")
+			), tokens);
 	}
 	
 	@Test


### PR DESCRIPTION
Performance is about 16 times faster and produced PDFs are about 20%-30% smaller. Also fixes 2 bugs.

Performance comparisons are based on two benchmarks I created: "Perf" generates 500 rows by 10 columns of cells with random text with a mix of line breaking point characters and varying lengths. It uses only text with no color or border styling. Perf is 15 times faster and generated a 28% smaller PDF with these enhancements. "Perf2" generates 500 rows of 8 columns with numbered and bulleted lists, italic and bold fonts, fill colors, and border styles. Perf2 is 17 times faster and generated a 20% smaller PDF. A variant of Perf2 with all rotated cells generated a 41% smaller PDF. The benchmark classes are in a separate branch, "benchmarks", which is not part of the pull request but provided for reference.

Most of the performance gains are from optimizing slow code paths. Also the rendering process avoids writing a lot of unnecessary operations to the PDF content stream.

One bug fixed was using the incorrect font style to calculate text width resulting in incorrect wrap points and text overflowing into adjacent cells. The other fix was the loss of text color setting with bullet lists.

I've run all the test PDFs and found them to be identical to the original code.

If you would like to discuss the changes or need me to break down the PR please let me know.