### PR TITLE
Issue #120: Add support for setting hyperlink URL on a Cell

### DIFF
--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -5,6 +5,7 @@
 package be.quodlibet.boxable;
 
 import java.awt.Color;
+import java.net.URL;
 import java.io.IOException;
 
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -20,6 +21,8 @@ public class Cell<T extends PDPage> {
 	private float width;
 	private Float height;
 	private String text;
+
+	private URL url = null;
 
 	private PDFont font = PDType1Font.HELVETICA;
 	private PDFont fontBold = PDType1Font.HELVETICA_BOLD;
@@ -742,6 +745,14 @@ public class Cell<T extends PDPage> {
 
 	public void setLineSpacing(float lineSpacing) {
 		this.lineSpacing = lineSpacing;
+	}
+
+	public URL getUrl() {
+		return url;
+	}
+
+	public void setUrl(URL url) {
+		this.url = url;
 	}
 
 }

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -17,8 +17,13 @@ import java.util.Map;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
+import org.apache.pdfbox.pdmodel.interactive.action.PDActionURI;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDBorderStyleDictionary;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageXYZDestination;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.apache.pdfbox.util.Matrix;
@@ -409,6 +414,28 @@ public abstract class Table<T extends PDPage> {
 					break;
 				}
 				imageCell.getImage().draw(document, tableContentStream, cursorX, cursorY);
+
+				if (imageCell.getUrl() != null) {
+					List<PDAnnotation> annotations = ((PDPage)currentPage).getAnnotations();
+
+					PDBorderStyleDictionary borderULine = new PDBorderStyleDictionary();
+					borderULine.setStyle(PDBorderStyleDictionary.STYLE_UNDERLINE);
+					borderULine.setWidth(1); // 1 point
+
+					PDAnnotationLink txtLink = new PDAnnotationLink();
+					txtLink.setBorderStyle(borderULine);
+
+					// Set the rectangle containing the link
+					// PDRectangle sets a the x,y and the width and height extend upwards from that!
+					PDRectangle position = new PDRectangle(cursorX, cursorY, (float)(imageCell.getImage().getWidth()), -(float)(imageCell.getImage().getHeight()));
+					txtLink.setRectangle(position);
+
+					// add an action
+					PDActionURI action = new PDActionURI();
+					action.setURI(imageCell.getUrl().toString());
+					txtLink.setAction(action);
+					annotations.add(txtLink);
+				}
 
 			} else if (cell instanceof TableCell) {
 				final TableCell<T> tableCell = (TableCell<T>) cell;


### PR DESCRIPTION
Just contributing back some changes made for my employer. I see this has also been requested as issue #120.

Call `Cell.setUrl()` to add a URI to your Cell; it will be rendered and clickable in the enclosing Table.
