### PR TITLE
Prevent rounding errors by diving the given width (percentage) by 100 first

### DIFF
--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -96,8 +96,8 @@ public class Cell<T extends PDPage> {
 			VerticalAlignment valign) {
 		this.row = row;
 		if (isCalculated) {
-			double calclulatedWidth = ((row.getWidth() * width) / 100);
-			this.width = (float) calclulatedWidth;
+			double calculatedWidth = row.getWidth() * (width / 100);
+			this.width = (float) calculatedWidth;
 		} else {
 			this.width = width;
 		}
@@ -353,7 +353,7 @@ public class Cell<T extends PDPage> {
 	 * <li>Normal value - cell's height is equal to {@link Paragraph}'s height
 	 * with necessery paddings (top,bottom)</li>
 	 * </ol>
-	 * 
+	 *
 	 * @return Cell's height
 	 * @throws IllegalStateException
 	 *             if <code>font</code> is not set.
@@ -623,7 +623,7 @@ public class Cell<T extends PDPage> {
 	/**
 	 * <p>
 	 * Easy setting for cell border style.
-	 * 
+	 *
 	 * @param border
 	 *            It is {@link LineStyle} for all borders
 	 * @see LineStyle Rendering line attributes


### PR DESCRIPTION
In my use case I have row width of 785.19684 (A4 width minus some margin). Creating a cell of width 100 percent via `row.createCell(100, value)` throws the following exception:

```
java.lang.IllegalArgumentException: Cell Width=785.1969 can't be bigger than row width=785.19684
	at be.quodlibet.boxable.Cell.<init>(Cell.java:107) ~[boxable-1.7.0.jar:na]
	at be.quodlibet.boxable.Cell.<init>(Cell.java:71) ~[boxable-1.7.0.jar:na]
	at be.quodlibet.boxable.Row.createCell(Row.java:51) ~[boxable-1.7.0.jar:na]
```

The problem is that digits are lost when multiplying the width float by 100 first. If we first calculate the percentage value such rounding errors should occur less often in this value range. 
In general, we should use doubles, big decimals, or don't define floating point widths at all to prevent rounding errors for arbitrary dimensions.