### PR TITLE
Add ability to listen to cell content being drawn.

### DIFF
--- a/src/main/java/be/quodlibet/boxable/Cell.java
+++ b/src/main/java/be/quodlibet/boxable/Cell.java
@@ -6,8 +6,12 @@ package be.quodlibet.boxable;
 
 import java.awt.Color;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 
@@ -53,6 +57,8 @@ public class Cell<T extends PDPage> {
 
 	float horizontalFreeSpace = 0;
 	float verticalFreeSpace = 0;
+
+	private final List<CellContentDrawnListener<T>> contentDrawnListenerList = new ArrayList<CellContentDrawnListener<T>>();
 
 	/**
 	 * <p>
@@ -744,4 +750,17 @@ public class Cell<T extends PDPage> {
 		this.lineSpacing = lineSpacing;
 	}
 
+	public void addContentDrawnListener(CellContentDrawnListener<T> listener) {
+		contentDrawnListenerList.add(listener);
+	}
+
+	public List<CellContentDrawnListener<T>> getCellContentDrawnListeners() {
+		return contentDrawnListenerList;
+	}
+
+	public void notifyContentDrawnListeners(PDDocument document, PDPage page, PDRectangle rectangle) {
+		for(CellContentDrawnListener<T> listener : getCellContentDrawnListeners()) {
+			listener.onContentDrawn(this, document, page, rectangle);
+		}
+	}
 }

--- a/src/main/java/be/quodlibet/boxable/CellContentDrawnListener.java
+++ b/src/main/java/be/quodlibet/boxable/CellContentDrawnListener.java
@@ -1,0 +1,9 @@
+package be.quodlibet.boxable;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+
+public interface CellContentDrawnListener<T extends PDPage> {
+    void onContentDrawn(Cell<T> cell, PDDocument document, PDPage page, PDRectangle rectangle);
+}

--- a/src/main/java/be/quodlibet/boxable/Table.java
+++ b/src/main/java/be/quodlibet/boxable/Table.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageXYZDestination;
@@ -670,6 +671,10 @@ public abstract class Table<T extends PDPage> {
                     }
                 }
             }
+
+            PDRectangle rectangle = new PDRectangle(cellStartX, yStart - cell.getHeight(), cell.getWidth(), cell.getHeight());
+            cell.notifyContentDrawnListeners(getDocument(), getCurrentPage(), rectangle);
+
             // set cursor to the start of this cell plus its width to advance to
             // the next cell
             cursorX = cellStartX + cell.getWidth();

--- a/src/test/java/be/quodlibet/boxable/TableTest.java
+++ b/src/test/java/be/quodlibet/boxable/TableTest.java
@@ -13,6 +13,7 @@ import be.quodlibet.boxable.utils.PageContentStreamOptimized;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
@@ -22,6 +23,9 @@ import be.quodlibet.boxable.utils.FontUtils;
 import be.quodlibet.boxable.utils.ImageUtils;
 import be.quodlibet.boxable.utils.PDStreamUtils;
 import java.nio.file.Files;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class TableTest {
 /**
@@ -1164,6 +1168,83 @@ public class TableTest {
 		file.getParentFile().mkdirs();
 		doc.save(file);
 		doc.close();
+	}
+
+	/**
+	 * <p>
+	 * Test for a  table using the following features :
+	 * <ul>
+	 * <li> using CellContentDrawnListener </li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @throws IOException
+	 */
+	@Test
+	public void SampleTest12() throws IOException {
+		// Set margins
+		float margin = 10;
+
+		// Initialize Document
+		PDDocument doc = new PDDocument();
+		PDPage page = new PDPage();
+		doc.addPage(page);
+
+		// Initialize table
+		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
+		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
+		boolean drawContent = true;
+		boolean drawLines = true;
+		float yStart = yStartNewPage;
+		float bottomMargin = 70;
+
+		// draw page title
+		PageContentStreamOptimized cos = new PageContentStreamOptimized(new PDPageContentStream(doc, page));
+		PDStreamUtils.write(cos, "Welcome to your first borderless table", PDType1Font.HELVETICA_BOLD, 14, 15, yStart,
+				Color.BLACK);
+		cos.close();
+
+		yStart -= FontUtils.getHeight(PDType1Font.HELVETICA_BOLD, 14) + 15;
+
+		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
+				drawContent);
+
+		// Create Header row
+		Row<PDPage> row = table.createRow(15f);
+		Cell<PDPage> cell = row.createCell(40f, "It's amazing what you can do with a little love in your heart. Maybe we got a few little happy bushes here, just covered with snow. Look around, look at what we have. Beauty is everywhere, you only have to look to see it. Anything you want to do you can do here.",
+				HorizontalAlignment.get("center"), VerticalAlignment.get("top"));
+		cell = row.createCell(20f, "Let your imagination be your guide. You could sit here for weeks with your one hair brush trying to do that - or you could do it with one stroke with an almighty brush. Let's get wild today. As trees get older they lose their chlorophyll.");
+		cell = row.createCell(40f, "Fluff it up a little and hypnotize it. Every highlight needs it's own personal shadow. If we're gonna walk though the woods, we need a little path. All kinds of happy little splashes. Of course he's a happy little stone, cause we don't have any other kind. In your world you have total and absolute power.");
+
+		table.addHeaderRow(row);
+
+		Row<PDPage> additionArow = table.createRow(15f);
+		cell = additionArow.createCell(40f, "If it's not what you want - stop and change it. Don't just keep going and expect it will get better. Nothing wrong with washing your brush. Remember how free clouds are. They just lay around in the sky all day long", HorizontalAlignment.get("center"),
+				VerticalAlignment.get("top"));
+		cell = additionArow.createCell(20f, "You are only limited by your imagination. Son of a gun. Let's have a happy little tree in here. The secret to doing anything is believing that you can do it. Anything that you believe you can do strong enough, you can do. Anything. As long as you believe.");
+		cell = additionArow.createCell(40f, "Everybody's different. Trees are different. Let them all be individuals. That's crazy. Even trees need a friend. We all need friends. Just go back and put one little more happy tree in there.");
+
+		final boolean[] callbackCalled = {false};
+		cell.addContentDrawnListener(new CellContentDrawnListener<PDPage>() {
+			@Override
+			public void onContentDrawn(Cell<PDPage> cell, PDDocument document, PDPage page, PDRectangle rectangle) {
+				assertEquals(365.20, rectangle.getLowerLeftX(), 0.001);
+				assertEquals(579.45, rectangle.getLowerLeftY(), 0.001);
+				assertEquals(602.00, rectangle.getUpperRightX(), 0.001);
+				assertEquals(665.45, rectangle.getUpperRightY(), 0.001);
+				callbackCalled[0] = true;
+			}
+		});
+		table.removeAllBorders(true);
+		table.draw();
+
+		// Save the document
+		File file = new File("target/BoxableSample12.pdf");
+		System.out.println("Sample file saved at : " + file.getAbsolutePath());
+		file.getParentFile().mkdirs();
+		doc.save(file);
+		doc.close();
+		assertTrue(callbackCalled[0]);
 	}
 
 	private static PDPage addNewPage(PDDocument doc) {


### PR DESCRIPTION
By adding a listener for when the content for a certain cell is drawn, that gives access to the actual document, page and rectangle the cell ends up occupying we gain the ability to for example create PDF annotations for hyperlinks (within the document or external URLs).

I have table cells that need to link to either internal pages in the document (e.g. table of contents) or external URLs, so having this interface allows me to support both without needing to add more code to Cell itself to support all of the variations, how you style the annotation etc.
