### PR TITLE
Add smart row wrapping and cleanup table drawing

### DIFF
--- a/src/main/java/be/quodlibet/boxable/DefaultRowWrappingFunction.java
+++ b/src/main/java/be/quodlibet/boxable/DefaultRowWrappingFunction.java
@@ -1,0 +1,64 @@
+package be.quodlibet.boxable;
+
+import org.apache.pdfbox.pdmodel.PDPage;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This Wrapping function allows you to create advanced table layouts by hiding borders,
+ * without braking them on pagebreaks. e.g.:
+ * ┌────┬──────┬──────┐
+ * ├────┼──────┤      │
+ * ├────┼──────┤      │
+ * ├────┼──────┤      │
+ * ├────┼──────┤      │
+ * ├────┼──────┤      │
+ * └────┴──────┴──────┘
+ * <p>
+ * is not broken between pages
+ */
+public class DefaultRowWrappingFunction implements RowWrappingFunction {
+
+
+    @Override
+    public <T extends PDPage> int[] getWrappableRows(List<Row<T>> rows) {
+        int[] wrapableRows = new int[rows.size()];
+        wrapableRows[0] = 0;
+        int j = 1;
+        for (int i = 1; i < rows.size(); i++) {
+            Row<?> row = rows.get(i);
+            if (isProperTableRowStart(row)) {
+                wrapableRows[j++] = i;
+            }
+        }
+        return Arrays.copyOf(wrapableRows, j);
+    }
+
+    /*
+     * Checks if this is a proper start of a table row,
+     * i.e. every cell is visibly closed by a border on top or has no sides anyway.
+     *
+     * allowed:
+     * "┌────┐", "      "
+     * not allowed:
+     * "│    │", "│     ","     │"
+     * */
+    private boolean isProperTableRowStart(Row<?> row) {
+        if (row.getCells().isEmpty()) {
+            return true;
+        }
+        boolean previousClosed = false;
+        for (Cell<?> cell : row.getCells()) {
+
+            if (cell.getTopBorder() == null && (cell.getLeftBorder() != null && !previousClosed)) {
+                return false;
+            }
+            previousClosed = cell.getTopBorder() != null;
+        }
+        Cell<?> lastCell = row.getCells().get(row.getCells().size() - 1);
+
+        return lastCell.getTopBorder() != null || (lastCell.getRightBorder() == null);
+    }
+
+}

--- a/src/main/java/be/quodlibet/boxable/Row.java
+++ b/src/main/java/be/quodlibet/boxable/Row.java
@@ -22,6 +22,7 @@ public class Row<T extends PDPage> {
 	private boolean headerRow = false;
 	float height;
 	private float lineSpacing = 1;
+	private float wrapHeight = -1;
 
 	Row(Table<T> table, List<Cell<T>> cells, float height) {
 		this.table = table;
@@ -284,5 +285,33 @@ public class Row<T extends PDPage> {
 
 	public void setLineSpacing(float lineSpacing) {
 		this.lineSpacing = lineSpacing;
+	}
+
+
+	/**
+	 * Finds out, taking restricted row wrapping into account, how much vertical space this row,
+	 * together with all un-wrappable rows that follow, will take.
+	 *
+	 * @return wrapHeight
+	 */
+	public float getWrapHeight() {
+		return table.calcWrapHeight(this);
+	}
+
+	protected void setWrapHeight(float wrapHeight) {
+		this.wrapHeight = wrapHeight;
+	}
+
+	protected float getSavedWrapHeight() {
+		return this.wrapHeight;
+	}
+
+	public boolean hasBottomBorder() {
+		for (Cell<T> cell : cells) {
+			if (cell.getBottomBorder() == null) {
+				return false;
+			}
+		}
+		return !cells.isEmpty();
 	}
 }

--- a/src/main/java/be/quodlibet/boxable/RowWrappingFunction.java
+++ b/src/main/java/be/quodlibet/boxable/RowWrappingFunction.java
@@ -1,0 +1,19 @@
+package be.quodlibet.boxable;
+
+import org.apache.pdfbox.pdmodel.PDPage;
+
+import java.util.List;
+
+/**
+ * This interface allows you to specify where in the table page breaks may be inserted.
+ */
+public interface RowWrappingFunction {
+
+
+	/**
+	 * Allows you to specify at which indexes rows that can be moved to the next page are.
+	 * @param rows list of rows to consider
+	 * @return indexes of rows that may be moved to the next page, if the current page is full
+	 */
+	<T extends PDPage> int[] getWrappableRows(List<Row<T>> rows);
+}

--- a/src/test/java/be/quodlibet/boxable/DataTableTest.java
+++ b/src/test/java/be/quodlibet/boxable/DataTableTest.java
@@ -2,7 +2,6 @@ package be.quodlibet.boxable;
 
 import be.quodlibet.boxable.datatable.DataTable;
 import be.quodlibet.boxable.datatable.UpdateCellProperty;
-import com.google.common.io.Files;
 import java.awt.Color;
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/be/quodlibet/boxable/TableTest.java
+++ b/src/test/java/be/quodlibet/boxable/TableTest.java
@@ -114,7 +114,7 @@ public class TableTest {
 					}
 				} else if(fact[i].equalsIgnoreCase("Google")) {
 					cell = row.createCell((100 / 9f), fact[i]);
-					cell.setFont(PDType1Font.HELVETICA_OBLIQUE);
+					cell.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA_OBLIQUE));
 					cell.setFontSize(6);
 					cell.setUrl(new URL("https://www.google.de"));
 				} else {
@@ -1209,11 +1209,11 @@ public class TableTest {
 
 		// draw page title
 		PageContentStreamOptimized cos = new PageContentStreamOptimized(new PDPageContentStream(doc, page));
-		PDStreamUtils.write(cos, "Welcome to your first borderless table", PDType1Font.HELVETICA_BOLD, 14, 15, yStart,
+		PDStreamUtils.write(cos, "Welcome to your first borderless table", new PDType1Font(Standard14Fonts.FontName.HELVETICA_BOLD), 14, 15, yStart,
 				Color.BLACK);
 		cos.close();
 
-		yStart -= FontUtils.getHeight(PDType1Font.HELVETICA_BOLD, 14) + 15;
+		yStart -= FontUtils.getHeight(new PDType1Font(Standard14Fonts.FontName.HELVETICA_BOLD), 14) + 15;
 
 		BaseTable table = new BaseTable(yStart, yStartNewPage, bottomMargin, tableWidth, margin, doc, page, drawLines,
 				drawContent);

--- a/src/test/java/be/quodlibet/boxable/TableTest.java
+++ b/src/test/java/be/quodlibet/boxable/TableTest.java
@@ -1256,6 +1256,76 @@ public class TableTest {
 		assertTrue(callbackCalled[0]);
 	}
 
+	/**
+	 * <p>
+	 * Test for a  table using the following features :
+	 * <ul>
+	 * <li> default row wrapping</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @throws IOException
+	 */
+	@Test
+	public void SampleTest13() throws IOException {
+		// Set margins
+		float margin = 10;
+
+		// Initialize Document
+		PDDocument doc = new PDDocument();
+		PDPage page = addNewPage(doc);
+
+		// Initialize table
+		float tableWidth = page.getMediaBox().getWidth() - (2 * margin);
+		float yStartNewPage = page.getMediaBox().getHeight() - (2 * margin);
+		boolean drawContent = true;
+		boolean drawLines = true;
+		float yStart = yStartNewPage;
+		float pageBottomMargin = 70;
+		float pageTopMargin = 2*margin;
+		BaseTable table = new BaseTable(yStart, yStartNewPage, pageBottomMargin, tableWidth, margin, doc, page, drawLines,
+				drawContent);
+
+		// set default line spacing for entire table
+		table.setLineSpacing(1.5f);
+
+		//ten unwrappable blocks
+		for (int i = 0; i < 10; i++) {
+			// first row in unwrappabe block
+			Row<PDPage> row = table.createRow(10f);
+			row.createCell(40,"first test");
+			row.createCell(30,"first test");
+			Cell<PDPage> lastCell = row.createCell(30, "first test");
+			lastCell.setBottomBorderStyle(null);
+
+			// 13 more rows
+			for (int j = 0; j < 13; j++) {
+				row = table.createRow(10f);
+				row.createCell(40,"test");
+				row.createCell(30,"test");
+				lastCell = row.createCell(30, "test");
+				lastCell.setBottomBorderStyle(null);
+				lastCell.setTopBorderStyle(null);
+			}
+			// last row in unwrappabe block
+			row = table.createRow(10f);
+			row.createCell(40,"test");
+			row.createCell(30,"test");
+			lastCell = row.createCell(30, "test");
+			lastCell.setTopBorderStyle(null);
+		}
+		table.draw();
+
+		// Save the document
+		File file = new File("target/BoxableSample13.pdf");
+		System.out.println("Sample file saved at : " + file.getAbsolutePath());
+		file.getParentFile().mkdirs();
+		doc.save(file);
+		doc.close();
+
+
+	}
+
 	private static PDPage addNewPage(PDDocument doc) {
 		PDPage page = new PDPage();
 		doc.addPage(page);


### PR DESCRIPTION
This PR contains two features improving the handling of null/not drawn borders I needed since I use boxable for layout.

It makes page wrapping a bit smarter. This prevents page breaks at visually wrong locations with null borders.  
The rows that are allowed to be wrapped to the next page can be customized using an interface similar to the one for word wrapping. 

Additionally, I cleaned up the logic for top border removal, and made it only remove the next top border, if the previous bottom border exists. This e.g. allows you to use borderless rows as separator between tables, without making those tables lose their top borders.  
This is very basic and could be improved further, allowing conflicting border styles and partial borders to be handled better.